### PR TITLE
Deploy after successful builds in master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - pushd site; sbt 'definitions/publishLocal' 'runtime/publishLocal' 'compiler/publishLocal' 'sbt-exercise/publishLocal' ; popd
   - sbt test
 after_success:
-  - ./deploy.sh
+  - bash deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,5 @@ script:
   - git clone https://github.com/scala-exercises/site.git site
   - pushd site; sbt 'definitions/publishLocal' 'runtime/publishLocal' 'compiler/publishLocal' 'sbt-exercise/publishLocal' ; popd
   - sbt test
-deploy:
-  provider: script
-  script: deploy.sh
-  skip_cleanup: true
-  on:
-    branch: master
+after_success:
+  - ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,5 @@ if [[ $TRAVIS_BRANCH == 'master' ]]; then
    release
 else
     echo "Not in master branch, skipping release"
-    # fixme: adding it here for testing in a non-master branch
-    release
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-function decipherKeys{
+function decipherKeys {
    echo $KEYS_PASSPHRASE | gpg --passphrase-fd 0 keys.tar.gpg
-   tar xfv keys.tar.gz
+   tar xfv keys.tar
 }
 
-function publish{
+function publish {
    sbt compile publishSigned
 }
 
@@ -14,7 +14,7 @@ function release {
     publish
 }
 
-if [[ $TRAVIS_BRANCH == 'master' ]]
+if [[ $TRAVIS_BRANCH == 'master' ]]; then
    echo "Master branch, releasing..."
    release
 else

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,25 @@
 #!/bin/sh
 
-echo $KEYS_PASSPHRASE | gpg --passphrase-fd 0 keys.tar.gpg
-tar xfv keys.tar.gz
-sbt compile publishSigned
+function decipherKeys{
+   echo $KEYS_PASSPHRASE | gpg --passphrase-fd 0 keys.tar.gpg
+   tar xfv keys.tar.gz
+}
+
+function publish{
+   sbt compile publishSigned
+}
+
+function release {
+    decipherKeys
+    publish
+}
+
+if [[ $TRAVIS_BRANCH == 'master' ]]
+   echo "Master branch, releasing..."
+   release
+else
+    echo "Not in master branch, skipping release"
+    # fixme: adding it here for testing in a non-master branch
+    release
+fi
+


### PR DESCRIPTION
The approach using Travis' `deploy` with a custom script is experimental, the output from the script isn't shown and made it difficult to see what was going on. I've used `after_success` and a custom script that checks whether the build is for the master branch.

@raulraja please take a look, [i tried publishing non-master in my tests](https://travis-ci.org/scala-exercises/exercises-cats/builds/138319161) and worked perfectly. If we are happy with this setup i'll open PRs for the other two content repos.