### PR TITLE
Add missed import in Apply

### DIFF
--- a/src/main/scala/catslib/Apply.scala
+++ b/src/main/scala/catslib/Apply.scala
@@ -137,6 +137,7 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
     res4: Option[(Int, Int)],
     res5: Option[(Int, Int, Int)]
   ) = {
+    import cats.implicits._
     val option2 = Option(1) |@| Option(2)
     val option3 = option2 |@| Option.empty[Int]
 


### PR DESCRIPTION
[Apply builder syntax](https://github.com/typelevel/cats/blob/master/docs/src/main/tut/apply.md#apply-builder-syntax) must import `cats.implicits._`

It's small but it stood out to me ;)

```scala
// Added for implicit instance, reference: https://github.com/typelevel/cats/blob/master/docs/src/main/tut/apply.md#apply-builder-syntax
import cats.implicits._  

val option2 = Option(1) |@| Option(2)
val option3 = option2 |@| Option.empty[Int]

option2 map addArity2
option3 map addArity3

option2 apWith Some(addArity2)
option3 apWith Some(addArity3)

option2.tupled
option3.tupled
```
