### PR TITLE
Update Foldable.scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ script:
 - sbt test
 
 before_install:
-- openssl aes-256-cbc -K $encrypted_00c350792894_key -iv $encrypted_00c350792894_iv
-  -in secring.gpg.enc -out secring.gpg -d
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+     openssl aes-256-cbc -K $encrypted_00c350792894_key -iv $encrypted_00c350792894_iv -in secring.gpg.enc -out secring.gpg -d;
+  fi
 
 after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/src/main/scala/catslib/Foldable.scala
+++ b/src/main/scala/catslib/Foldable.scala
@@ -143,7 +143,7 @@ object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.de
     * needed. The `A` will be discarded and `Unit` returned instead.
     *
     */
-  def foldableTraverse(res0: Option[Unit], res1: Option[Unit]) = {
+  def foldableTraverse(res0: Option[Any], res1: Option[Unit]) = {
     import cats.implicits._
     import cats.data.Xor
 


### PR DESCRIPTION
By expecting the function argument Option[Unit], the type is force and wrong answers such as Some(1) or Some("hi") also work because they are converted to type Unit. By expanding the expected type to Any, we require the answer be Some(()) or Some()