### PR TITLE
Integrates sbt-org-policies plugin

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,23 @@
+style = defaultWithAlign
+maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
      sbt compile publishSigned;
   fi
-- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-     echo "Not in master branch, skipping deploy and release";
-  fi

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
-#Scala Exercises - Cats library
-
+# Scala Exercises - Cats library
 ------------------------
 
 This repository hosts a content library for the [Scala Exercises](https://www.scala-exercises.org/) platform, that includes interactive exercises related to the [Cats library](https://github.com/typelevel/cats) by Typelevel.
 
-##About Scala exercises
+## About Scala exercises
 
 "Scala Exercises" brings exercises for the Stdlib, Cats, Shapeless and many other great libraries for Scala to your browser. Offering hundreds of solvable exercises organized into several categories covering the basics of the Scala language and its most important libraries.
 
 Scala Exercises is available at [scala-exercises.org](https://scala-exercises.org).
 
-##Contributing
+## Contributing
 
 Contributions are welcome! Please join our [Gitter channel](https://gitter.im/scala-exercises/scala-exercises)
 to get involved, or visit our [GitHub site](https://github.com/scala-exercises).
 
-##License
+## License
 
 Copyright (C) 2015-2016 47 Degrees, LLC.
 Reactive, scalable software solutions.

--- a/build.sbt
+++ b/build.sbt
@@ -1,51 +1,25 @@
+val scalaExerciesV = "0.4.0-SNAPSHOT"
+
+def dep(artifactId: String) =
+  "org.scala-exercises" %% artifactId % scalaExerciesV excludeAll ExclusionRule("org.typelevel")
+
 lazy val cats = (project in file("."))
-.settings(publishSettings:_*)
-.enablePlugins(ExerciseCompilerPlugin)
-.settings(
-  organization := "org.scala-exercises",
-  name         := "exercises-cats",
-  scalaVersion := "2.11.8",
-  version := "0.3.0-SNAPSHOT",
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
-  ),
-  libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core" % "0.7.2",
-    "com.chuusai" %% "shapeless" % "2.2.5",
-    "org.scalatest" %% "scalatest" % "2.2.4",
-    "org.scala-exercises" %% "exercise-compiler" % version.value,
-    "org.scala-exercises" %% "definitions" % version.value,
-    "org.scalacheck" %% "scalacheck" % "1.12.5",
-    "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.0")
+  .enablePlugins(ExerciseCompilerPlugin)
+  .settings(
+    name         := "exercises-cats",
+    libraryDependencies ++= Seq(
+      dep("exercise-compiler"),
+      dep("definitions"),
+      %%("cats-core", "0.7.2"),
+      %%("shapeless"),
+      %%("scalatest"),
+      %%("scalacheck"),
+      %%("scheckShapeless")
+    )
   )
-)
 
 // Distribution
 
-lazy val gpgFolder = sys.env.getOrElse("PGP_FOLDER", ".")
-
-lazy val publishSettings = Seq(
-  organizationName := "Scala Exercises",
-  organizationHomepage := Some(new URL("http://scala-exercises.org")),
-  startYear := Some(2016),
-  description := "Scala Exercises: The path to enlightenment",
-  homepage := Some(url("http://scala-exercises.org")),
-  pgpPassphrase := Some(sys.env.getOrElse("PGP_PASSPHRASE", "").toCharArray),
-  pgpPublicRing := file(s"$gpgFolder/pubring.gpg"),
-  pgpSecretRing := file(s"$gpgFolder/secring.gpg"),
-  credentials += Credentials("Sonatype Nexus Repository Manager",  "oss.sonatype.org",  sys.env.getOrElse("PUBLISH_USERNAME", ""),  sys.env.getOrElse("PUBLISH_PASSWORD", "")),
-  scmInfo := Some(ScmInfo(url("https://github.com/scala-exercises/exercises-cats"), "https://github.com/scala-exercises/exercises-cats.git")),
-  licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  pomIncludeRepository := Function.const(false),
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("Snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("Releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-)
+pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
+pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
+pgpSecretRing := file(s"$gpgFolder/secring.gpg")

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,0 +1,46 @@
+import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbtorgpolicies._
+import sbtorgpolicies.model._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
+
+object ProjectPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      description := "Scala Exercises: The path to enlightenment",
+      startYear := Option(2016),
+      orgGithubSetting := GitHubSettings(
+        organization = "scala-exercises",
+        project = name.value,
+        organizationName = "Scala Exercises",
+        groupId = "org.scala-exercises",
+        organizationHomePage = url("https://www.scala-exercises.org"),
+        organizationEmail = "hello@47deg.com"
+      ),
+      orgLicenseSetting := ApacheLicense,
+      scalaVersion := "2.11.8",
+      scalaOrganization := "org.scala-lang",
+      crossScalaVersions := Seq("2.11.8"),
+      resolvers ++= Seq(
+        Resolver.mavenLocal,
+        Resolver.sonatypeRepo("snapshots"),
+        Resolver.sonatypeRepo("releases")
+      ),
+      headers := Map(
+        "scala" -> (HeaderPattern.cStyleBlockComment,
+          s"""|/*
+              | * scala-exercises - ${name.value}
+              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+              | */
+              |
+            |""".stripMargin)
+      )
+    )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.3.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.3.2")

--- a/src/main/scala/catslib/Applicative.scala
+++ b/src/main/scala/catslib/Applicative.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -6,23 +11,26 @@ import cats._
 import cats.implicits._
 
 /** `Applicative` extends `Apply` by adding a single method, `pure`:
-  *
-  * {{{
-  * def pure[A](x: A): F[A]
-  * }}}
-  *
-  *
-  * @param name applicative
-  */
-object ApplicativeSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * {{{
+ * def pure[A](x: A): F[A]
+ * }}}
+ *
+ *
+ * @param name applicative
+ */
+object ApplicativeSection
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** This method takes any value and returns the value in the context of
-    * the functor. For many familiar functors, how to do this is
-    * obvious. For `Option`, the `pure` operation wraps the value in
-    * `Some`. For `List`, the `pure` operation returns a single element
-    * `List`:
-    *
-    */
+   * the functor. For many familiar functors, how to do this is
+   * obvious. For `Option`, the `pure` operation wraps the value in
+   * `Some`. For `List`, the `pure` operation returns a single element
+   * `List`:
+   *
+   */
   def pureMethod(res0: Option[Int], res1: List[Int]) = {
     import cats._
     import cats.implicits._
@@ -32,24 +40,23 @@ object ApplicativeSection extends FlatSpec with Matchers with org.scalaexercises
   }
 
   /** Like `Functor` and `Apply`, `Applicative`
-    * functors also compose naturally with each other. When
-    * you compose one `Applicative` with another, the resulting `pure`
-    * operation will lift the passed value into one context, and the result
-    * into the other context:
-    */
-  def applicativeComposition(res0: List[Option[Int]]) = {
+   * functors also compose naturally with each other. When
+   * you compose one `Applicative` with another, the resulting `pure`
+   * operation will lift the passed value into one context, and the result
+   * into the other context:
+   */
+  def applicativeComposition(res0: List[Option[Int]]) =
     (Applicative[List] compose Applicative[Option]).pure(1) should be(res0)
-  }
 
   /** = Applicative Functors & Monads =
-    *
-    * `Applicative` is a generalization of `Monad`, allowing expression
-    * of effectful computations in a pure functional way.
-    *
-    * `Applicative` is generally preferred to `Monad` when the structure of a
-    * computation is fixed a priori. That makes it possible to perform certain
-    * kinds of static analysis on applicative values.
-    */
+   *
+   * `Applicative` is a generalization of `Monad`, allowing expression
+   * of effectful computations in a pure functional way.
+   *
+   * `Applicative` is generally preferred to `Monad` when the structure of a
+   * computation is fixed a priori. That makes it possible to perform certain
+   * kinds of static analysis on applicative values.
+   */
   def applicativesAndMonads(res0: Option[Int], res1: Option[Int]) = {
     Monad[Option].pure(1) should be(res0)
     Applicative[Option].pure(1) should be(res1)

--- a/src/main/scala/catslib/Apply.scala
+++ b/src/main/scala/catslib/Apply.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -7,50 +12,51 @@ import cats._
 import cats.implicits._
 
 /** `Apply` extends the `Functor` type class (which features the familiar `map`
-  * function) with a new function `ap`. The `ap` function is similar to `map`
-  * in that we are transforming a value in a context (a context being the `F` in `F[A]`;
-  * a context can be `Option`, `List` or `Future` for example).
-  * However, the difference between `ap` and `map` is that for `ap` the function that
-  * takes care of the transformation is of type `F[A => B]`, whereas for `map` it is `A => B`:
-  *
-  * Here are the implementations of `Apply` for the `Option` and `List` types:
-  * {{{
-  * import cats._
-  *
-  * implicit val optionApply: Apply[Option] = new Apply[Option] {
-  * def ap[A, B](f: Option[A => B])(fa: Option[A]): Option[B] =
-  *  fa.flatMap (a => f.map (ff => ff(a)))
-  *
-  * def map[A,B](fa: Option[A])(f: A => B): Option[B] = fa map f
-  *
-  * def product[A, B](fa: Option[A], fb: Option[B]): Option[(A, B)] =
-  *  fa.flatMap(a => fb.map(b => (a, b)))
-  * }
-  *
-  * implicit val listApply: Apply[List] = new Apply[List] {
-  * def ap[A, B](f: List[A => B])(fa: List[A]): List[B] =
-  *  fa.flatMap (a => f.map (ff => ff(a)))
-  *
-  * def map[A,B](fa: List[A])(f: A => B): List[B] = fa map f
-  *
-  * def product[A, B](fa: List[A], fb: List[B]): List[(A, B)] =
-  *  fa.zip(fb)
-  * }
-  * }}}
-  *
-  * @param name apply
-  */
+ * function) with a new function `ap`. The `ap` function is similar to `map`
+ * in that we are transforming a value in a context (a context being the `F` in `F[A]`;
+ * a context can be `Option`, `List` or `Future` for example).
+ * However, the difference between `ap` and `map` is that for `ap` the function that
+ * takes care of the transformation is of type `F[A => B]`, whereas for `map` it is `A => B`:
+ *
+ * Here are the implementations of `Apply` for the `Option` and `List` types:
+ * {{{
+ * import cats._
+ *
+ * implicit val optionApply: Apply[Option] = new Apply[Option] {
+ * def ap[A, B](f: Option[A => B])(fa: Option[A]): Option[B] =
+ *  fa.flatMap (a => f.map (ff => ff(a)))
+ *
+ * def map[A,B](fa: Option[A])(f: A => B): Option[B] = fa map f
+ *
+ * def product[A, B](fa: Option[A], fb: Option[B]): Option[(A, B)] =
+ *  fa.flatMap(a => fb.map(b => (a, b)))
+ * }
+ *
+ * implicit val listApply: Apply[List] = new Apply[List] {
+ * def ap[A, B](f: List[A => B])(fa: List[A]): List[B] =
+ *  fa.flatMap (a => f.map (ff => ff(a)))
+ *
+ * def map[A,B](fa: List[A])(f: A => B): List[B] = fa map f
+ *
+ * def product[A, B](fa: List[A], fb: List[B]): List[(A, B)] =
+ *  fa.zip(fb)
+ * }
+ * }}}
+ *
+ * @param name apply
+ */
 object ApplySection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** = map =
-    *
-    * Since `Apply` extends `Functor`, we can use the `map` method from `Functor`:
-    */
+   *
+   * Since `Apply` extends `Functor`, we can use the `map` method from `Functor`:
+   */
   def applyExtendsFunctor(res0: Option[String], res1: Option[Int], res2: Option[Int]) = {
     import cats.implicits._
 
     val intToString: Int ⇒ String = _.toString
-    val double: Int ⇒ Int = _ * 2
-    val addTwo: Int ⇒ Int = _ + 2
+    val double: Int ⇒ Int         = _ * 2
+    val addTwo: Int ⇒ Int         = _ + 2
 
     Apply[Option].map(Some(1))(intToString) should be(res0)
     Apply[Option].map(Some(1))(double) should be(res1)
@@ -58,9 +64,9 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = compose =
-    *
-    * And like functors, `Apply` instances also compose:
-    */
+   *
+   * And like functors, `Apply` instances also compose:
+   */
   def applyComposes(res0: List[Option[Int]]) = {
     val listOpt = Apply[List] compose Apply[Option]
     val plusOne = (x: Int) ⇒ x + 1
@@ -68,10 +74,15 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = ap =
-    *
-    * The `ap` method is a method that `Functor` does not have:
-    */
-  def applyAp(res0: Option[String], res1: Option[Int], res2: Option[Int], res3: Option[Int], res4: Option[Int]) = {
+   *
+   * The `ap` method is a method that `Functor` does not have:
+   */
+  def applyAp(
+      res0: Option[String],
+      res1: Option[Int],
+      res2: Option[Int],
+      res3: Option[Int],
+      res4: Option[Int]) = {
     Apply[Option].ap(Some(intToString))(Some(1)) should be(res0)
     Apply[Option].ap(Some(double))(Some(1)) should be(res1)
     Apply[Option].ap(Some(double))(None) should be(res2)
@@ -80,14 +91,14 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = ap2, ap3, etc =
-    *
-    * `Apply` also offers variants of `ap`. The functions `apN` (for `N` between `2` and `22`)
-    * accept `N` arguments where `ap` accepts `1`.
-    *
-    * Note that if any of the arguments of this example is `None`, the
-    * final result is `None` as well.  The effects of the context we are operating on
-    * are carried through the entire computation:
-    */
+   *
+   * `Apply` also offers variants of `ap`. The functions `apN` (for `N` between `2` and `22`)
+   * accept `N` arguments where `ap` accepts `1`.
+   *
+   * Note that if any of the arguments of this example is `None`, the
+   * final result is `None` as well.  The effects of the context we are operating on
+   * are carried through the entire computation:
+   */
   def applyApn(res0: Option[Int], res1: Option[Int], res2: Option[Int]) = {
     val addArity2 = (a: Int, b: Int) ⇒ a + b
     Apply[Option].ap2(Some(addArity2))(Some(1), Some(2)) should be(res0)
@@ -98,10 +109,10 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = map2, map3, etc =
-    *
-    * Similarly, `mapN` functions are available:
-    *
-    */
+   *
+   * Similarly, `mapN` functions are available:
+   *
+   */
   def applyMapn(res0: Option[Int], res1: Option[Int]) = {
     Apply[Option].map2(Some(1), Some(2))(addArity2) should be(res0)
 
@@ -109,31 +120,31 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = tuple2, tuple3, etc =
-    *
-    * Similarly, `tupleN` functions are available:
-    *
-    */
+   *
+   * Similarly, `tupleN` functions are available:
+   *
+   */
   def applyTuplen(res0: Option[(Int, Int)], res1: Option[(Int, Int, Int)]) = {
     Apply[Option].tuple2(Some(1), Some(2)) should be(res0)
     Apply[Option].tuple3(Some(1), Some(2), Some(3)) should be(res1)
   }
 
   /** = apply builder syntax =
-    *
-    * The `|@|` operator offers an alternative syntax for the higher-arity `Apply`
-    * functions (`apN`, `mapN` and `tupleN`).
-    * In order to use it, first import `cats.implicits._`.
-    *
-    * All instances created by `|@|` have `map`, `ap`, and `tupled` methods of the appropriate arity:
-    *
-    */
+   *
+   * The `|@|` operator offers an alternative syntax for the higher-arity `Apply`
+   * functions (`apN`, `mapN` and `tupleN`).
+   * In order to use it, first import `cats.implicits._`.
+   *
+   * All instances created by `|@|` have `map`, `ap`, and `tupled` methods of the appropriate arity:
+   *
+   */
   def applyBuilderSyntax(
-    res0: Option[Int],
-    res1: Option[Int],
-    res2: Option[Int],
-    res3: Option[Int],
-    res4: Option[(Int, Int)],
-    res5: Option[(Int, Int, Int)]
+      res0: Option[Int],
+      res1: Option[Int],
+      res2: Option[Int],
+      res3: Option[Int],
+      res4: Option[(Int, Int)],
+      res5: Option[(Int, Int, Int)]
   ) = {
     import cats.implicits._
     val option2 = Option(1) |@| Option(2)

--- a/src/main/scala/catslib/ApplyHelpers.scala
+++ b/src/main/scala/catslib/ApplyHelpers.scala
@@ -1,9 +1,14 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 object ApplyHelpers {
   val intToString: Int ⇒ String = _.toString
-  val double: Int ⇒ Int = _ * 2
-  val addTwo: Int ⇒ Int = _ + 2
-  val addArity2 = (a: Int, b: Int) ⇒ a + b
-  val addArity3 = (a: Int, b: Int, c: Int) ⇒ a + b + c
+  val double: Int ⇒ Int         = _ * 2
+  val addTwo: Int ⇒ Int         = _ + 2
+  val addArity2                 = (a: Int, b: Int) ⇒ a + b
+  val addArity3                 = (a: Int, b: Int, c: Int) ⇒ a + b + c
 }

--- a/src/main/scala/catslib/CatsLibrary.scala
+++ b/src/main/scala/catslib/CatsLibrary.scala
@@ -1,11 +1,16 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 /** Cats is a library which provides abstractions for functional programming in the Scala programming language.
-  *
-  * @param name cats
-  */
+ *
+ * @param name cats
+ */
 object CatsLibrary extends org.scalaexercises.definitions.Library {
-  override def owner = "scala-exercises"
+  override def owner      = "scala-exercises"
   override def repository = "exercises-cats"
 
   override def color = Some("#5B5988")

--- a/src/main/scala/catslib/Foldable.scala
+++ b/src/main/scala/catslib/Foldable.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -6,118 +11,120 @@ import cats._
 import cats.implicits._
 
 /** Foldable type class instances can be defined for data structures that can be
-  * folded to a summary value.
-  *
-  * In the case of a collection (such as `List` or `Set`), these methods will fold
-  * together (combine) the values contained in the collection to produce a single
-  * result. Most collection types have `foldLeft` methods, which will usually be
-  * used by the associated `Foldable[_]` instance.
-  *
-  * `Foldable[F]` is implemented in terms of two basic methods:
-  *
-  *   - `foldLeft(fa, b)(f)` eagerly folds `fa` from left-to-right.
-  *   - `foldRight(fa, b)(f)` lazily folds `fa` from right-to-left.
-  *
-  *
-  * These form the basis for many other operations, see also:
-  * [[http://www.cs.nott.ac.uk/~pszgmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
-  *
-  * First some standard imports.
-  *
-  * {{{
-  * import cats._
-  * import cats.implicits._
-  * }}}
-  *
-  * Apart from the familiar `foldLeft` and `foldRight`, `Foldable` has a number of other useful functions.
-  *
-  * @param name foldable
-  */
+ * folded to a summary value.
+ *
+ * In the case of a collection (such as `List` or `Set`), these methods will fold
+ * together (combine) the values contained in the collection to produce a single
+ * result. Most collection types have `foldLeft` methods, which will usually be
+ * used by the associated `Foldable[_]` instance.
+ *
+ * `Foldable[F]` is implemented in terms of two basic methods:
+ *
+ *   - `foldLeft(fa, b)(f)` eagerly folds `fa` from left-to-right.
+ *   - `foldRight(fa, b)(f)` lazily folds `fa` from right-to-left.
+ *
+ *
+ * These form the basis for many other operations, see also:
+ * [[http://www.cs.nott.ac.uk/~pszgmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
+ *
+ * First some standard imports.
+ *
+ * {{{
+ * import cats._
+ * import cats.implicits._
+ * }}}
+ *
+ * Apart from the familiar `foldLeft` and `foldRight`, `Foldable` has a number of other useful functions.
+ *
+ * @param name foldable
+ */
 object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** = foldLeft =
-    *
-    * `foldLeft` is an eager left-associative fold on `F` using the given function.
-    *
-    */
+   *
+   * `foldLeft` is an eager left-associative fold on `F` using the given function.
+   *
+   */
   def foldableFoldLeft(res0: Int, res1: String) = {
     Foldable[List].foldLeft(List(1, 2, 3), 0)(_ + _) should be(res0)
     Foldable[List].foldLeft(List("a", "b", "c"), "")(_ + _) should be(res1)
   }
 
   /** = foldRight =
-    *
-    * `foldRight` is a lazy right-associative fold on `F` using the given function.
-    * The function has the signature `(A, Eval[B]) => Eval[B]` to support laziness in
-    * a stack-safe way.
-    *
-    */
+   *
+   * `foldRight` is a lazy right-associative fold on `F` using the given function.
+   * The function has the signature `(A, Eval[B]) => Eval[B]` to support laziness in
+   * a stack-safe way.
+   *
+   */
   def foldableFoldRight(res0: Int) = {
-    val lazyResult = Foldable[List].foldRight(List(1, 2, 3), Now(0))((x, rest) ⇒ Later(x + rest.value))
+    val lazyResult =
+      Foldable[List].foldRight(List(1, 2, 3), Now(0))((x, rest) ⇒ Later(x + rest.value))
     lazyResult.value should be(res0)
   }
 
   /** = fold =
-    *
-    * `fold`, also called `combineAll`, combines every value in the foldable using the given `Monoid` instance.
-    *
-    */
+   *
+   * `fold`, also called `combineAll`, combines every value in the foldable using the given `Monoid` instance.
+   *
+   */
   def foldableFold(res0: String, res1: Int) = {
     Foldable[List].fold(List("a", "b", "c")) should be(res0)
     Foldable[List].fold(List(1, 2, 3)) should be(res1) // Hint: the implicit monoid for `Int` is the Sum monoid
   }
 
   /** = foldMap =
-    *
-    * `foldMap` is similar to `fold` but maps every `A` value into `B` and then
-    * combines them using the given `Monoid[B]` instance.
-    *
-    */
+   *
+   * `foldMap` is similar to `fold` but maps every `A` value into `B` and then
+   * combines them using the given `Monoid[B]` instance.
+   *
+   */
   def foldableFoldMap(res0: Int, res1: String) = {
     Foldable[List].foldMap(List("a", "b", "c"))(_.length) should be(res0)
     Foldable[List].foldMap(List(1, 2, 3))(_.toString) should be(res1)
   }
 
   /** = foldK =
-    *
-    * `foldK` is similar to `fold` but combines every value in the foldable using the given `MonoidK[G]` instance
-    * instead of `Monoid[G]`.
-    */
+   *
+   * `foldK` is similar to `fold` but combines every value in the foldable using the given `MonoidK[G]` instance
+   * instead of `Monoid[G]`.
+   */
   def foldableFoldk(res0: List[Int], res1: Option[String]) = {
     Foldable[List].foldK(List(List(1, 2), List(3, 4, 5))) should be(res0)
     Foldable[List].foldK(List(None, Option("two"), Option("three"))) should be(res1)
   }
 
   /** = find =
-    *
-    * `find` searches for the first element matching the predicate, if one exists.
-    */
+   *
+   * `find` searches for the first element matching the predicate, if one exists.
+   */
   def foldableFind(res0: Option[Int], res1: Option[Int]) = {
     Foldable[List].find(List(1, 2, 3))(_ > 2) should be(res0)
     Foldable[List].find(List(1, 2, 3))(_ > 5) should be(res1)
   }
 
   /** = exists =
-    *
-    * `exists` checks whether at least one element satisfies the predicate.
-    */
+   *
+   * `exists` checks whether at least one element satisfies the predicate.
+   */
   def foldableExists(res0: Boolean, res1: Boolean) = {
     Foldable[List].exists(List(1, 2, 3))(_ > 2) should be(res0)
     Foldable[List].exists(List(1, 2, 3))(_ > 5) should be(res1)
   }
 
   /** = forall =
-    *
-    * `forall` checks whether all elements satisfy the predicate.
-    */
+   *
+   * `forall` checks whether all elements satisfy the predicate.
+   */
   def foldableForall(res0: Boolean, res1: Boolean) = {
     Foldable[List].forall(List(1, 2, 3))(_ <= 3) should be(res0)
     Foldable[List].forall(List(1, 2, 3))(_ < 3) should be(res1)
   }
 
   /** = toList =
-    *
-    * Convert `F[A]` to `List[A]`.
-    */
+   *
+   * Convert `F[A]` to `List[A]`.
+   */
   def foldableTolist(res0: List[Int], res1: List[Int], res2: List[Int]) = {
     Foldable[List].toList(List(1, 2, 3)) should be(res0)
     Foldable[Option].toList(Option(42)) should be(res1)
@@ -125,24 +132,24 @@ object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.de
   }
 
   /** = filter_ =
-    *
-    * Convert `F[A]` to `List[A]` only including the elements that match a predicate.
-    */
+   *
+   * Convert `F[A]` to `List[A]` only including the elements that match a predicate.
+   */
   def foldableFilter(res0: List[Int], res1: List[Int]) = {
     Foldable[List].filter_(List(1, 2, 3))(_ < 3) should be(res0)
     Foldable[Option].filter_(Option(42))(_ != 42) should be(res1)
   }
 
   /** = traverse_ =
-    *
-    * `traverse` the foldable mapping `A` values to `G[B]`, and combining
-    * them using `Applicative[G]` and discarding the results.
-    *
-    * This method is primarily useful when `G[_]` represents an action
-    * or effect, and the specific `B` aspect of `G[B]` is not otherwise
-    * needed. The `B` will be discarded and `Unit` returned instead.
-    *
-    */
+   *
+   * `traverse` the foldable mapping `A` values to `G[B]`, and combining
+   * them using `Applicative[G]` and discarding the results.
+   *
+   * This method is primarily useful when `G[_]` represents an action
+   * or effect, and the specific `B` aspect of `G[B]` is not otherwise
+   * needed. The `B` will be discarded and `Unit` returned instead.
+   *
+   */
   def foldableTraverse(res0: Option[Unit], res1: Option[Unit]) = {
     import cats.implicits._
     import cats.data.Xor
@@ -155,9 +162,9 @@ object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.de
   }
 
   /** = compose =
-    *
-    * We can compose `Foldable[F[_]]` and `Foldable[G[_]]` instances to obtain `Foldable[F[G]]`.
-    */
+   *
+   * We can compose `Foldable[F[_]]` and `Foldable[G[_]]` instances to obtain `Foldable[F[G]]`.
+   */
   def foldableCompose(res0: Int, res1: String) = {
     val FoldableListOption = Foldable[List].compose[Option]
     FoldableListOption.fold(List(Option(1), Option(2), Option(3), Option(4))) should be(res0)
@@ -165,16 +172,16 @@ object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.de
   }
 
   /** = More Foldable methods =
-    *
-    * Hence when defining some new data structure, if we can define a `foldLeft` and
-    * `foldRight` we are able to provide many other useful operations, if not always
-    * the most efficient implementations, over the structure without further
-    * implementation.
-    *
-    * There are a few more methods that we haven't talked about but you probably can
-    * guess what they do:
-    *
-    */
+   *
+   * Hence when defining some new data structure, if we can define a `foldLeft` and
+   * `foldRight` we are able to provide many other useful operations, if not always
+   * the most efficient implementations, over the structure without further
+   * implementation.
+   *
+   * There are a few more methods that we haven't talked about but you probably can
+   * guess what they do:
+   *
+   */
   def foldableMethods(res0: Boolean, res1: List[Int], res2: List[Int]) = {
     Foldable[List].isEmpty(List(1, 2, 3)) should be(res0)
     Foldable[List].dropWhile_(List(1, 2, 3))(_ < 2) should be(res1)

--- a/src/main/scala/catslib/FunctorSection.scala
+++ b/src/main/scala/catslib/FunctorSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -6,113 +11,114 @@ import cats._
 import cats.implicits._
 
 /** A `Functor` is a ubiquitous type class involving types that have one
-  * "hole", i.e. types which have the shape `F[?]`, such as `Option`,
-  * `List` and `Future`. (This is in contrast to a type like `Int` which has
-  * no hole, or `Tuple2` which has two holes (`Tuple2[?,?]`)).
-  *
-  * The `Functor` category involves a single operation, named `map`:
-  *
-  * {{{
-  * def map[A, B](fa: F[A])(f: A => B): F[B]
-  * }}}
-  *
-  * This method takes a function `A => B` and turns an `F[A]` into an
-  * `F[B]`.  The name of the method `map` should remind you of the `map`
-  * method that exists on many classes in the Scala standard library, for
-  * example:
-  *
-  * {{{
-  * Option(1).map(_ + 1)
-  * List(1,2,3).map(_ + 1)
-  * Vector(1,2,3).map(_.toString)
-  * }}}
-  *
-  * = Creating Functor instances =
-  *
-  * We can trivially create a `Functor` instance for a type which has a well
-  * behaved `map` method:
-  *
-  * {{{
-  * import cats._
-  *
-  * implicit val optionFunctor: Functor[Option] = new Functor[Option] {
-  * def map[A,B](fa: Option[A])(f: A => B) = fa map f
-  * }
-  *
-  * implicit val listFunctor: Functor[List] = new Functor[List] {
-  * def map[A,B](fa: List[A])(f: A => B) = fa map f
-  * }
-  * }}}
-  *
-  * However, functors can also be created for types which don't have a `map`
-  * method. For example, if we create a `Functor` for `Function1[In, ?]`
-  * we can use `andThen` to implement `map`:
-  *
-  * {{{
-  * implicit def function1Functor[In]: Functor[Function1[In, ?]] =
-  * new Functor[Function1[In, ?]] {
-  *  def map[A,B](fa: In => A)(f: A => B): Function1[In,B] = fa andThen f
-  * }
-  * }}}
-  *
-  * This example demonstrates the use of the
-  * [[https://github.com/non/kind-projector kind-projector compiler plugin]]
-  * This compiler plugin can help us when we need to change the number of type
-  * holes. In the example above, we took a type which normally has two type holes,
-  * `Function1[?,?]` and constrained one of the holes to be the `In` type,
-  * leaving just one hole for the return type, resulting in `Function1[In,?]`.
-  * Without kind-projector, we'd have to write this as something like
-  * `({type F[A] = Function1[In,A]})#F`, which is much harder to read and understand.
-  *
-  * @param name functor
-  */
+ * "hole", i.e. types which have the shape `F[?]`, such as `Option`,
+ * `List` and `Future`. (This is in contrast to a type like `Int` which has
+ * no hole, or `Tuple2` which has two holes (`Tuple2[?,?]`)).
+ *
+ * The `Functor` category involves a single operation, named `map`:
+ *
+ * {{{
+ * def map[A, B](fa: F[A])(f: A => B): F[B]
+ * }}}
+ *
+ * This method takes a function `A => B` and turns an `F[A]` into an
+ * `F[B]`.  The name of the method `map` should remind you of the `map`
+ * method that exists on many classes in the Scala standard library, for
+ * example:
+ *
+ * {{{
+ * Option(1).map(_ + 1)
+ * List(1,2,3).map(_ + 1)
+ * Vector(1,2,3).map(_.toString)
+ * }}}
+ *
+ * = Creating Functor instances =
+ *
+ * We can trivially create a `Functor` instance for a type which has a well
+ * behaved `map` method:
+ *
+ * {{{
+ * import cats._
+ *
+ * implicit val optionFunctor: Functor[Option] = new Functor[Option] {
+ * def map[A,B](fa: Option[A])(f: A => B) = fa map f
+ * }
+ *
+ * implicit val listFunctor: Functor[List] = new Functor[List] {
+ * def map[A,B](fa: List[A])(f: A => B) = fa map f
+ * }
+ * }}}
+ *
+ * However, functors can also be created for types which don't have a `map`
+ * method. For example, if we create a `Functor` for `Function1[In, ?]`
+ * we can use `andThen` to implement `map`:
+ *
+ * {{{
+ * implicit def function1Functor[In]: Functor[Function1[In, ?]] =
+ * new Functor[Function1[In, ?]] {
+ *  def map[A,B](fa: In => A)(f: A => B): Function1[In,B] = fa andThen f
+ * }
+ * }}}
+ *
+ * This example demonstrates the use of the
+ * [[https://github.com/non/kind-projector kind-projector compiler plugin]]
+ * This compiler plugin can help us when we need to change the number of type
+ * holes. In the example above, we took a type which normally has two type holes,
+ * `Function1[?,?]` and constrained one of the holes to be the `In` type,
+ * leaving just one hole for the return type, resulting in `Function1[In,?]`.
+ * Without kind-projector, we'd have to write this as something like
+ * `({type F[A] = Function1[In,A]})#F`, which is much harder to read and understand.
+ *
+ * @param name functor
+ */
 object FunctorSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** = Using Functor =
-    *
-    * == map ==
-    *
-    * `List` is a functor which applies the function to each element of the list:
-    *
-    * {{{
-    * Functor[List].map(List("qwer", "adsfg"))(_.length)
-    * }}}
-    *
-    * `Option` is a functor which only applies the function when the `Option` value
-    * is a `Some`:
-    *
-    */
+   *
+   * == map ==
+   *
+   * `List` is a functor which applies the function to each element of the list:
+   *
+   * {{{
+   * Functor[List].map(List("qwer", "adsfg"))(_.length)
+   * }}}
+   *
+   * `Option` is a functor which only applies the function when the `Option` value
+   * is a `Some`:
+   *
+   */
   def usingFunctor(res0: Option[Int], res1: Option[Int]) = {
     Functor[Option].map(Option("Hello"))(_.length) should be(res0)
     Functor[Option].map(None: Option[String])(_.length) should be(res1)
   }
 
   /** = Derived methods =
-    *
-    * == lift ==
-    *
-    * We can use `Functor` to "lift" a function from `A => B` to `F[A] => F[B]`:
-    *
-    * {{{
-    * val lenOption: Option[String] => Option[Int] = Functor[Option].lift(_.length)
-    * lenOption(Some("abcd"))
-    * }}}
-    *
-    * We can now apply the `lenOption` function to `Option` instances.
-    *
-    */
+   *
+   * == lift ==
+   *
+   * We can use `Functor` to "lift" a function from `A => B` to `F[A] => F[B]`:
+   *
+   * {{{
+   * val lenOption: Option[String] => Option[Int] = Functor[Option].lift(_.length)
+   * lenOption(Some("abcd"))
+   * }}}
+   *
+   * We can now apply the `lenOption` function to `Option` instances.
+   *
+   */
   def liftingToAFunctor(res0: Option[Int]) = {
     val lenOption: Option[String] ⇒ Option[Int] = Functor[Option].lift(_.length)
     lenOption(Some("Hello")) should be(res0)
   }
 
   /** == fproduct ==
-    *
-    * `Functor` provides an `fproduct` function which pairs a value with the
-    * result of applying a function to that value.
-    *
-    */
+   *
+   * `Functor` provides an `fproduct` function which pairs a value with the
+   * result of applying a function to that value.
+   *
+   */
   def usingFproduct(res0: Int, res1: Int, res2: Int) = {
-    val source = List("Cats", "is", "awesome")
+    val source  = List("Cats", "is", "awesome")
     val product = Functor[List].fproduct(source)(_.length).toMap
 
     product.get("Cats").getOrElse(0) should be(res0)
@@ -121,18 +127,18 @@ object FunctorSection extends FlatSpec with Matchers with org.scalaexercises.def
   }
 
   /** == compose ==
-    *
-    * Functors compose! Given any functor `F[_]` and any functor `G[_]` we can
-    * create a new functor `F[G[_]]` by composing them:
-    *
-    * {{{
-    * val listOpt = Functor[List] compose Functor[Option]
-    * }}}
-    *
-    * In the previous example the resulting functor will apply the `map` operation through the two
-    * type constructors: `List` and `Option`.
-    *
-    */
+   *
+   * Functors compose! Given any functor `F[_]` and any functor `G[_]` we can
+   * create a new functor `F[G[_]]` by composing them:
+   *
+   * {{{
+   * val listOpt = Functor[List] compose Functor[Option]
+   * }}}
+   *
+   * In the previous example the resulting functor will apply the `map` operation through the two
+   * type constructors: `List` and `Option`.
+   *
+   */
   def composingFunctors(res0: List[Option[Int]]) = {
     val listOpt = Functor[List] compose Functor[Option]
     listOpt.map(List(Some(1), None, Some(3)))(_ + 1) should be(res0)

--- a/src/main/scala/catslib/IdentitySection.scala
+++ b/src/main/scala/catslib/IdentitySection.scala
@@ -1,83 +1,87 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import cats._
 import org.scalatest._
 
 /** The identity monad can be seen as the ambient monad that encodes the
-  * effect of having no effect. It is ambient in the sense that plain pure
-  * values are values of `Id`.
-  *
-  * It is encoded as:
-  *
-  * {{{
-  * type Id[A] = A
-  * }}}
-  *
-  * That is to say that the type Id[A] is just a synonym for A.  We can
-  * freely treat values of type `A` as values of type `Id[A]`, and
-  * vice-versa.
-  *
-  * {{{
-  * import cats._
-  *
-  * val x: Id[Int] = 1
-  * val y: Int = x
-  * }}}
-  *
-  * @param name identity
-  */
+ * effect of having no effect. It is ambient in the sense that plain pure
+ * values are values of `Id`.
+ *
+ * It is encoded as:
+ *
+ * {{{
+ * type Id[A] = A
+ * }}}
+ *
+ * That is to say that the type Id[A] is just a synonym for A.  We can
+ * freely treat values of type `A` as values of type `Id[A]`, and
+ * vice-versa.
+ *
+ * {{{
+ * import cats._
+ *
+ * val x: Id[Int] = 1
+ * val y: Int = x
+ * }}}
+ *
+ * @param name identity
+ */
 object IdentitySection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** We can freely compare values of `Id[T]` with unadorned
-    * values of type `T`.
-    */
+   * values of type `T`.
+   */
   def identityType(res0: Int) {
     val anId: Id[Int] = 42
     anId should be(res0)
   }
 
   /** Using this type declaration, we can treat our Id type constructor as a
-    * `Monad` and as a `Comonad`. The `pure`
-    * method, which has type `A => Id[A]` just becomes the identity
-    * function.  The `map` method from `Functor` just becomes function
-    * application:
-    *
-    * {{{
-    * import cats.Functor
-    *
-    * val one: Int = 1
-    * Functor[Id].map(one)(_ + 1)
-    * }}}
-    *
-    */
-  def pureIdentity(res0: Int) = {
+   * `Monad` and as a `Comonad`. The `pure`
+   * method, which has type `A => Id[A]` just becomes the identity
+   * function.  The `map` method from `Functor` just becomes function
+   * application:
+   *
+   * {{{
+   * import cats.Functor
+   *
+   * val one: Int = 1
+   * Functor[Id].map(one)(_ + 1)
+   * }}}
+   *
+   */
+  def pureIdentity(res0: Int) =
     Applicative[Id].pure(42) should be(res0)
-  }
 
   /** Compare the signatures of `map` and `flatMap` and `coflatMap`:
-    *
-    * {{{
-    * def map[A, B](fa: Id[A])(f: A => B): Id[B]
-    * def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B]
-    * def coflatMap[A, B](a: Id[A])(f: Id[A] => B): Id[B]
-    * }}}
-    *
-    * You'll notice that in the flatMap signature, since `Id[B]` is the same
-    * as `B` for all B, we can rewrite the type of the `f` parameter to be
-    * `A => B` instead of `A => Id[B]`, and this makes the signatures of the
-    * two functions the same, and, in fact, they can have the same
-    * implementation, meaning that for `Id`, `flatMap` is also just function
-    * application:
-    *
-    * {{{
-    * import cats.Monad
-    *
-    * val one: Int = 1
-    * Monad[Id].map(one)(_ + 1)
-    * Monad[Id].flatMap(one)(_ + 1)
-    * }}}
-    *
-    */
+   *
+   * {{{
+   * def map[A, B](fa: Id[A])(f: A => B): Id[B]
+   * def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B]
+   * def coflatMap[A, B](a: Id[A])(f: Id[A] => B): Id[B]
+   * }}}
+   *
+   * You'll notice that in the flatMap signature, since `Id[B]` is the same
+   * as `B` for all B, we can rewrite the type of the `f` parameter to be
+   * `A => B` instead of `A => Id[B]`, and this makes the signatures of the
+   * two functions the same, and, in fact, they can have the same
+   * implementation, meaning that for `Id`, `flatMap` is also just function
+   * application:
+   *
+   * {{{
+   * import cats.Monad
+   *
+   * val one: Int = 1
+   * Monad[Id].map(one)(_ + 1)
+   * Monad[Id].flatMap(one)(_ + 1)
+   * }}}
+   *
+   */
   def idComonad(res0: Int) = {
     val fortytwo: Int = 42
     Comonad[Id].coflatMap(fortytwo)(_ + 1) should be(res0)

--- a/src/main/scala/catslib/Monad.scala
+++ b/src/main/scala/catslib/Monad.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -6,16 +11,17 @@ import cats._
 import MonadHelpers._
 
 /** `Monad` extends the `Applicative` type class with a
-  * new function `flatten`. Flatten takes a value in a nested context (eg.
-  * `F[F[A]]` where F is the context) and "joins" the contexts together so
-  * that we have a single context (ie. `F[A]`).
-  *
-  * @param name monad
-  */
+ * new function `flatten`. Flatten takes a value in a nested context (eg.
+ * `F[F[A]]` where F is the context) and "joins" the contexts together so
+ * that we have a single context (ie. `F[A]`).
+ *
+ * @param name monad
+ */
 object MonadSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** The name `flatten` should remind you of the functions of the same name on many
-    * classes in the standard library.
-    */
+   * classes in the standard library.
+   */
   def flattenRecap(res0: Option[Int], res1: Option[Int], res2: List[Int]) = {
     Option(Option(1)).flatten should be(res0)
     Option(None).flatten should be(res1)
@@ -23,33 +29,33 @@ object MonadSection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = Monad instances =
-    *
-    * If `Applicative` is already present and `flatten` is well-behaved,
-    * extending the `Applicative` to a `Monad` is trivial. To provide evidence
-    * that a type belongs in the `Monad` type class, cats' implementation
-    * requires us to provide an implementation of `pure` (which can be reused
-    * from `Applicative`) and `flatMap`.
-    *
-    * We can use `flatten` to define `flatMap`: `flatMap` is just `map`
-    * followed by `flatten`. Conversely, `flatten` is just `flatMap` using
-    * the identity function `x => x` (i.e. `flatMap(_)(x => x)`).
-    *
-    * {{{
-    * import cats._
-    *
-    * implicit def optionMonad(implicit app: Applicative[Option]) =
-    * new Monad[Option] {
-    *  // Define flatMap using Option's flatten method
-    *  override def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
-    *    app.map(fa)(f).flatten
-    *  // Reuse this definition from Applicative.
-    *  override def pure[A](a: A): Option[A] = app.pure(a)
-    * }
-    * }}}
-    *
-    * Cats already provides a `Monad` instance of `Option`.
-    *
-    */
+   *
+   * If `Applicative` is already present and `flatten` is well-behaved,
+   * extending the `Applicative` to a `Monad` is trivial. To provide evidence
+   * that a type belongs in the `Monad` type class, cats' implementation
+   * requires us to provide an implementation of `pure` (which can be reused
+   * from `Applicative`) and `flatMap`.
+   *
+   * We can use `flatten` to define `flatMap`: `flatMap` is just `map`
+   * followed by `flatten`. Conversely, `flatten` is just `flatMap` using
+   * the identity function `x => x` (i.e. `flatMap(_)(x => x)`).
+   *
+   * {{{
+   * import cats._
+   *
+   * implicit def optionMonad(implicit app: Applicative[Option]) =
+   * new Monad[Option] {
+   *  // Define flatMap using Option's flatten method
+   *  override def flatMap[A, B](fa: Option[A])(f: A => Option[B]): Option[B] =
+   *    app.map(fa)(f).flatten
+   *  // Reuse this definition from Applicative.
+   *  override def pure[A](a: A): Option[A] = app.pure(a)
+   * }
+   * }}}
+   *
+   * Cats already provides a `Monad` instance of `Option`.
+   *
+   */
   def monadInstances(res0: Option[Int]) = {
     import cats._
     import cats.implicits._
@@ -58,22 +64,22 @@ object MonadSection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = flatMap =
-    *
-    * `flatMap` is often considered to be the core function of `Monad`, and cats
-    * follows this tradition by providing implementations of `flatten` and `map`
-    * derived from `flatMap` and `pure`.
-    *
-    * {{{
-    * implicit val listMonad = new Monad[List] {
-    * def flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
-    * def pure[A](a: A): List[A] = List(a)
-    * }
-    * }}}
-    *
-    * Part of the reason for this is that name `flatMap` has special significance in
-    * scala, as for-comprehensions rely on this method to chain together operations
-    * in a monadic context.
-    */
+   *
+   * `flatMap` is often considered to be the core function of `Monad`, and cats
+   * follows this tradition by providing implementations of `flatten` and `map`
+   * derived from `flatMap` and `pure`.
+   *
+   * {{{
+   * implicit val listMonad = new Monad[List] {
+   * def flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
+   * def pure[A](a: A): List[A] = List(a)
+   * }
+   * }}}
+   *
+   * Part of the reason for this is that name `flatMap` has special significance in
+   * scala, as for-comprehensions rely on this method to chain together operations
+   * in a monadic context.
+   */
   def monadFlatmap(res0: List[Int]) = {
     import cats._
     import cats.implicits._
@@ -82,11 +88,11 @@ object MonadSection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = ifM =
-    *
-    * `Monad` provides the ability to choose later operations in a sequence based on
-    * the results of earlier ones. This is embodied in `ifM`, which lifts an `if`
-    * statement into the monadic context.
-    */
+   *
+   * `Monad` provides the ability to choose later operations in a sequence based on
+   * the results of earlier ones. This is embodied in `ifM`, which lifts an `if`
+   * statement into the monadic context.
+   */
   def monadIfm(res0: Option[String], res1: List[Int]) = {
     import cats._
     import cats.implicits._
@@ -96,37 +102,37 @@ object MonadSection extends FlatSpec with Matchers with org.scalaexercises.defin
   }
 
   /** = Composition =
-    *
-    * Unlike `Functor`s and `Applicative`s, you cannot derive a monad instance for a generic `M[N[_]]`
-    * where both `M[_]` and `N[_]` have an instance of a monad.
-    *
-    * However, it is common to want to compose the effects of both `M[_]` and `N[_]`. One way of expressing this
-    * is to provide instructions on how to compose any outer monad (`F` in the following example) with a specific
-    * inner monad (`Option` in the following example).
-    *
-    * {{{
-    * case class OptionT[F[_], A](value: F[Option[A]])
+   *
+   * Unlike `Functor`s and `Applicative`s, you cannot derive a monad instance for a generic `M[N[_]]`
+   * where both `M[_]` and `N[_]` have an instance of a monad.
+   *
+   * However, it is common to want to compose the effects of both `M[_]` and `N[_]`. One way of expressing this
+   * is to provide instructions on how to compose any outer monad (`F` in the following example) with a specific
+   * inner monad (`Option` in the following example).
+   *
+   * {{{
+   * case class OptionT[F[_], A](value: F[Option[A]])
 
-    * implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
-    *   new Monad[OptionT[F, ?]] {
-    *     def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
-    *     def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
-    *       OptionT {
-    *         F.flatMap(fa.value) {
-    *           case None => F.pure(None)
-    *           case Some(a) => f(a).value
-    *         }
-    *       }
-    *     def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
-    *       defaultTailRecM(a)(f)
-    *   }
-    * }
-    * }}}
-    *
-    * This sort of construction is called a monad transformer. Cats already provides
-    * a monad transformer for `Option` called `OptionT`.
-    *
-    */
+   * implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
+   *   new Monad[OptionT[F, ?]] {
+   *     def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
+   *     def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
+   *       OptionT {
+   *         F.flatMap(fa.value) {
+   *           case None => F.pure(None)
+   *           case Some(a) => f(a).value
+   *         }
+   *       }
+   *     def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
+   *       defaultTailRecM(a)(f)
+   *   }
+   * }
+   * }}}
+   *
+   * This sort of construction is called a monad transformer. Cats already provides
+   * a monad transformer for `Option` called `OptionT`.
+   *
+   */
   def monadComposition(res0: List[Option[Int]]) = {
     import cats.implicits._
 

--- a/src/main/scala/catslib/MonadHelpers.scala
+++ b/src/main/scala/catslib/MonadHelpers.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import cats.Monad

--- a/src/main/scala/catslib/Monoid.scala
+++ b/src/main/scala/catslib/Monoid.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -6,34 +11,35 @@ import cats._
 import cats.implicits._
 
 /** `Monoid` extends the `Semigroup` type class, adding an
-  * `empty` method to semigroup's `combine`. The `empty` method must return a
-  * value that when combined with any other instance of that type returns the
-  * other instance, i.e.
-  *
-  * {{{
-  * (combine(x, empty) == combine(empty, x) == x)
-  * }}}
-  *
-  * For example, if we have a `Monoid[String]` with `combine` defined as string
-  * concatenation, then `empty = ""`.
-  *
-  * Having an `empty` defined allows us to combine all the elements of some
-  * potentially empty collection of `T` for which a `Monoid[T]` is defined and
-  * return a `T`, rather than an `Option[T]` as we have a sensible default to
-  * fall back to.
-  *
-  * @param name monoid
-  */
+ * `empty` method to semigroup's `combine`. The `empty` method must return a
+ * value that when combined with any other instance of that type returns the
+ * other instance, i.e.
+ *
+ * {{{
+ * (combine(x, empty) == combine(empty, x) == x)
+ * }}}
+ *
+ * For example, if we have a `Monoid[String]` with `combine` defined as string
+ * concatenation, then `empty = ""`.
+ *
+ * Having an `empty` defined allows us to combine all the elements of some
+ * potentially empty collection of `T` for which a `Monoid[T]` is defined and
+ * return a `T`, rather than an `Option[T]` as we have a sensible default to
+ * fall back to.
+ *
+ * @param name monoid
+ */
 object MonoidSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** First some imports.
-    *
-    * {{{
-    * import cats._
-    * import cats.implicits._
-    * }}}
-    *
-    * And let's see the implicit instance of `Monoid[String]` in action.
-    */
+   *
+   * {{{
+   * import cats._
+   * import cats.implicits._
+   * }}}
+   *
+   * And let's see the implicit instance of `Monoid[String]` in action.
+   */
   def monoidEmpty(res0: String, res1: String, res2: String) = {
     import cats.implicits._
 
@@ -43,19 +49,19 @@ object MonoidSection extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /** The advantage of using these type class provided methods, rather than the
-    * specific ones for each type, is that we can compose monoids to allow us to
-    * operate on more complex types, e.g.
-    */
+   * specific ones for each type, is that we can compose monoids to allow us to
+   * operate on more complex types, e.g.
+   */
   def monoidAdvantage(res0: Map[String, Int], res1: Map[String, Int]) = {
     Monoid[Map[String, Int]].combineAll(List(Map("a" → 1, "b" → 2), Map("a" → 3))) should be(res0)
     Monoid[Map[String, Int]].combineAll(List()) should be(res1)
   }
 
   /** This is also true if we define our own instances. As an example, let's use
-    * `Foldable`'s `foldMap`, which maps over values accumulating
-    * the results, using the available `Monoid` for the type mapped onto.
-    *
-    */
+   * `Foldable`'s `foldMap`, which maps over values accumulating
+   * the results, using the available `Monoid` for the type mapped onto.
+   *
+   */
   def monoidFoldmap(res0: Int, res1: String) = {
     val l = List(1, 2, 3, 4, 5)
     l.foldMap(identity) should be(res0)
@@ -63,24 +69,24 @@ object MonoidSection extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /** To use this
-    * with a function that produces a tuple, we can define a `Monoid` for a tuple
-    * that will be valid for any tuple where the types it contains also have a
-    * `Monoid` available. Note that cats already defines it for you.
-    *
-    * {{{
-    *     implicit def monoidTuple[A: Monoid, B: Monoid]: Monoid[(A, B)] =
-    *       new Monoid[(A, B)] {
-    *         def combine(x: (A, B), y: (A, B)): (A, B) = {
-    *           val (xa, xb) = x
-    *           val (ya, yb) = y
-    *           (Monoid[A].combine(xa, ya), Monoid[B].combine(xb, yb))
-    *         }
-    *         def empty: (A, B) = (Monoid[A].empty, Monoid[B].empty)
-    *       }
-    * }}}
-    *
-    * This way we are able to combine both values in one pass, hurrah!
-    */
+   * with a function that produces a tuple, we can define a `Monoid` for a tuple
+   * that will be valid for any tuple where the types it contains also have a
+   * `Monoid` available. Note that cats already defines it for you.
+   *
+   * {{{
+   *     implicit def monoidTuple[A: Monoid, B: Monoid]: Monoid[(A, B)] =
+   *       new Monoid[(A, B)] {
+   *         def combine(x: (A, B), y: (A, B)): (A, B) = {
+   *           val (xa, xb) = x
+   *           val (ya, yb) = y
+   *           (Monoid[A].combine(xa, ya), Monoid[B].combine(xb, yb))
+   *         }
+   *         def empty: (A, B) = (Monoid[A].empty, Monoid[B].empty)
+   *       }
+   * }}}
+   *
+   * This way we are able to combine both values in one pass, hurrah!
+   */
   def tupleMonoid(res0: (Int, String)) = {
     val l = List(1, 2, 3, 4, 5)
     l.foldMap(i ⇒ (i, i.toString)) should be(res0)

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -5,92 +10,111 @@ import org.scalatest._
 import cats._
 
 /** A semigroup for some given type A has a single operation
-  * (which we will call `combine`), which takes two values of type A, and
-  * returns a value of type A. This operation must be guaranteed to be
-  * associative. That is to say that:
-  *
-  * {{{
-  * ((a combine b) combine c)
-  * }}}
-  *
-  * must be the same as
-  *
-  * {{{
-  * (a combine (b combine c))
-  * }}}
-  *
-  * for all possible values of a,b,c.
-  *
-  * There are instances of `Semigroup` defined for many types found in the
-  * scala common library. For example, `Int` values are combined using addition
-  * by default but multiplication is also associative and forms another `Semigroup`.
-  *
-  * {{{
-  * import cats.Semigroup
-  * }}}
-  *
-  * @param name semigroup
-  */
-object SemigroupSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ * (which we will call `combine`), which takes two values of type A, and
+ * returns a value of type A. This operation must be guaranteed to be
+ * associative. That is to say that:
+ *
+ * {{{
+ * ((a combine b) combine c)
+ * }}}
+ *
+ * must be the same as
+ *
+ * {{{
+ * (a combine (b combine c))
+ * }}}
+ *
+ * for all possible values of a,b,c.
+ *
+ * There are instances of `Semigroup` defined for many types found in the
+ * scala common library. For example, `Int` values are combined using addition
+ * by default but multiplication is also associative and forms another `Semigroup`.
+ *
+ * {{{
+ * import cats.Semigroup
+ * }}}
+ *
+ * @param name semigroup
+ */
+object SemigroupSection
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
+
   /** Now that you've learned about the `Semigroup` instance for `Int` try to
-    * guess how it works in the following examples:
-    *
-    */
-  def semigroupCombine(res0: Int, res1: List[Int], res2: Option[Int], res3: Option[Int], res4: Int) = {
+   * guess how it works in the following examples:
+   *
+   */
+  def semigroupCombine(
+      res0: Int,
+      res1: List[Int],
+      res2: Option[Int],
+      res3: Option[Int],
+      res4: Int) = {
     import cats.implicits._
 
     Semigroup[Int].combine(1, 2) should be(res0)
     Semigroup[List[Int]].combine(List(1, 2, 3), List(4, 5, 6)) should be(res1)
     Semigroup[Option[Int]].combine(Option(1), Option(2)) should be(res2)
     Semigroup[Option[Int]].combine(Option(1), None) should be(res3)
-    Semigroup[Int ⇒ Int].combine({ (x: Int) ⇒ x + 1 }, { (x: Int) ⇒ x * 10 }).apply(6) should be(res4)
+    Semigroup[Int ⇒ Int]
+      .combine({ (x: Int) ⇒
+        x + 1
+      }, { (x: Int) ⇒
+        x * 10
+      })
+      .apply(6) should be(res4)
   }
 
   /** Many of these types have methods defined directly on them,
-    * which allow for such combining, e.g. `++` on List, but the
-    * value of having a `Semigroup` type class available is that these
-    * compose, so for instance, we can say
-    *
-    * {{{
-    * Map("foo" -> Map("bar" -> 5)).combine(Map("foo" -> Map("bar" -> 6), "baz" -> Map()))
-    * Map("foo" -> List(1, 2)).combine(Map("foo" -> List(3,4), "bar" -> List(42)))
-    * }}}
-    *
-    * which is far more likely to be useful than
-    *
-    * {{{
-    * Map("foo" -> Map("bar" -> 5)) ++  Map("foo" -> Map("bar" -> 6), "baz" -> Map())
-    * Map("foo" -> List(1, 2)) ++ Map("foo" -> List(3,4), "bar" -> List(42))
-    * }}}
-    *
-    * since the first version uses the Semigroup's `combine` operation, it will merge
-    * the map's values with `combine`.
-    */
+   * which allow for such combining, e.g. `++` on List, but the
+   * value of having a `Semigroup` type class available is that these
+   * compose, so for instance, we can say
+   *
+   * {{{
+   * Map("foo" -> Map("bar" -> 5)).combine(Map("foo" -> Map("bar" -> 6), "baz" -> Map()))
+   * Map("foo" -> List(1, 2)).combine(Map("foo" -> List(3,4), "bar" -> List(42)))
+   * }}}
+   *
+   * which is far more likely to be useful than
+   *
+   * {{{
+   * Map("foo" -> Map("bar" -> 5)) ++  Map("foo" -> Map("bar" -> 6), "baz" -> Map())
+   * Map("foo" -> List(1, 2)) ++ Map("foo" -> List(3,4), "bar" -> List(42))
+   * }}}
+   *
+   * since the first version uses the Semigroup's `combine` operation, it will merge
+   * the map's values with `combine`.
+   */
   def composingSemigroups(res0: Map[String, Int]) = {
     import cats.implicits._
 
-    val aMap = Map("foo" → Map("bar" → 5))
-    val anotherMap = Map("foo" → Map("bar" → 6))
+    val aMap        = Map("foo" → Map("bar" → 5))
+    val anotherMap  = Map("foo" → Map("bar" → 6))
     val combinedMap = Semigroup[Map[String, Map[String, Int]]].combine(aMap, anotherMap)
 
     combinedMap.get("foo") should be(Some(res0))
   }
 
   /** There is inline syntax available for `Semigroup`. Here we are
-    * following the convention from scalaz, that `|+|` is the
-    * operator from `Semigroup`.
-    *
-    * You'll notice that instead of declaring `one` as `Some(1)`, I chose
-    * `Option(1)`, and I added an explicit type declaration for `n`. This is
-    * because there aren't type class instances for Some or None, but for
-    * Option.
-    */
-  def semigroupSpecialSyntax(res0: Option[Int], res1: Option[Int], res2: Option[Int], res3: Option[Int]) = {
+   * following the convention from scalaz, that `|+|` is the
+   * operator from `Semigroup`.
+   *
+   * You'll notice that instead of declaring `one` as `Some(1)`, I chose
+   * `Option(1)`, and I added an explicit type declaration for `n`. This is
+   * because there aren't type class instances for Some or None, but for
+   * Option.
+   */
+  def semigroupSpecialSyntax(
+      res0: Option[Int],
+      res1: Option[Int],
+      res2: Option[Int],
+      res3: Option[Int]) = {
     import cats.implicits._
 
     val one: Option[Int] = Option(1)
     val two: Option[Int] = Option(2)
-    val n: Option[Int] = None
+    val n: Option[Int]   = None
 
     one |+| two should be(res0)
     n |+| two should be(res1)

--- a/src/main/scala/catslib/Traverse.scala
+++ b/src/main/scala/catslib/Traverse.scala
@@ -1,212 +1,218 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
 
-import cats.data.{ Xor, ValidatedNel }
+import cats.data.{ValidatedNel, Xor}
 import cats.implicits._
 
 import TraverseHelpers._
 
 /** In functional programming it is very common to encode "effects" as data types - common effects
-  * include `Option` for possibly missing values, `Xor` and `Validated` for possible errors, and
-  * `Future` for asynchronous computations.
-  *
-  * These effects tend to show up in functions working on a single piece of data - for instance
-  * parsing a single `String` into an `Int`, validating a login, or asynchronously fetching website
-  * information for a user.
-  *
-  * {{{
-  * import cats.data.Xor
-  * import scala.concurrent.Future
-  *
-  * def parseInt(s: String): Option[Int] = ???
-  *
-  * trait SecurityError
-  * trait Credentials
-  *
-  * def validateLogin(cred: Credentials): Xor[SecurityError, Unit] = ???
-  *
-  * trait Profile
-  * trait User
-  *
-  * def userInfo(user: User): Future[Profile] = ???
-  * }}}
-  *
-  * Each function asks only for the data it actually needs; in the case of `userInfo`, a single `User`. We
-  * certainly could write one that takes a `List[User]` and fetch profile for all of them, would be a bit strange.
-  * If we just wanted to fetch the profile of just one user, we would either have to wrap it in a `List` or write
-  * a separate function that takes in a single user anyways. More fundamentally, functional programming is about
-  * building lots of small, independent pieces and composing them to make larger and larger pieces - does this
-  * hold true in this case?
-  *
-  * Given just `User => Future[Profile]`, what should we do if we want to fetch profiles for a `List[User]`?
-  * We could try familiar combinators like `map`.
-  *
-  * {{{
-  * def profilesFor(users: List[User]): List[Future[Profile]] = users.map(userInfo)
-  * }}}
-  *
-  * Note the return type `List[Future[Profile]]`. This makes sense given the type signatures, but seems unwieldy.
-  * We now have a list of asynchronous values, and to work with those values we must then use the combinators on
-  * `Future` for every single one. It would be nicer instead if we could get the aggregate result in a single
-  * `Future`, say a `Future[List[Profile]]`.
-  *
-  * As it turns out, the `Future` companion object has a `traverse` method on it. However, that method is
-  * specialized to standard library collections and `Future`s - there exists a much more generalized form
-  * that would allow us to parse a `List[String]` or validate credentials for a `List[User]`.
-  *
-  * Enter `Traverse`.
-  *
-  * = The type class =
-  * At center stage of `Traverse` is the `traverse` method.
-  *
-  * {{{
-  * trait Traverse[F[_]] {
-  * def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
-  * }
-  * }}}
-  *
-  * In our above example, `F` is `List`, and `G` is `Option`, `Xor`, or `Future`. For the profile example,
-  * `traverse` says given a `List[User]` and a function `User => Future[Profile]`, it can give you a
-  * `Future[List[Profile]]`.
-  *
-  * Abstracting away the `G` (still imagining `F` to be `List`), `traverse` says given a collection of data,
-  * and a function that takes a piece of data and returns an effectful value, it will traverse the collection,
-  * applying the function and aggregating the effectful values (in a `List`) as it goes.
-  *
-  * In the most general form, `F[_]` is some sort of context which may contain a value (or several). While
-  * `List` tends to be among the most general cases, there also exist `Traverse` instances for `Option`,
-  * `Xor`, and `Validated` (among others).
-  *
-  * @param name traverse
-  */
+ * include `Option` for possibly missing values, `Xor` and `Validated` for possible errors, and
+ * `Future` for asynchronous computations.
+ *
+ * These effects tend to show up in functions working on a single piece of data - for instance
+ * parsing a single `String` into an `Int`, validating a login, or asynchronously fetching website
+ * information for a user.
+ *
+ * {{{
+ * import cats.data.Xor
+ * import scala.concurrent.Future
+ *
+ * def parseInt(s: String): Option[Int] = ???
+ *
+ * trait SecurityError
+ * trait Credentials
+ *
+ * def validateLogin(cred: Credentials): Xor[SecurityError, Unit] = ???
+ *
+ * trait Profile
+ * trait User
+ *
+ * def userInfo(user: User): Future[Profile] = ???
+ * }}}
+ *
+ * Each function asks only for the data it actually needs; in the case of `userInfo`, a single `User`. We
+ * certainly could write one that takes a `List[User]` and fetch profile for all of them, would be a bit strange.
+ * If we just wanted to fetch the profile of just one user, we would either have to wrap it in a `List` or write
+ * a separate function that takes in a single user anyways. More fundamentally, functional programming is about
+ * building lots of small, independent pieces and composing them to make larger and larger pieces - does this
+ * hold true in this case?
+ *
+ * Given just `User => Future[Profile]`, what should we do if we want to fetch profiles for a `List[User]`?
+ * We could try familiar combinators like `map`.
+ *
+ * {{{
+ * def profilesFor(users: List[User]): List[Future[Profile]] = users.map(userInfo)
+ * }}}
+ *
+ * Note the return type `List[Future[Profile]]`. This makes sense given the type signatures, but seems unwieldy.
+ * We now have a list of asynchronous values, and to work with those values we must then use the combinators on
+ * `Future` for every single one. It would be nicer instead if we could get the aggregate result in a single
+ * `Future`, say a `Future[List[Profile]]`.
+ *
+ * As it turns out, the `Future` companion object has a `traverse` method on it. However, that method is
+ * specialized to standard library collections and `Future`s - there exists a much more generalized form
+ * that would allow us to parse a `List[String]` or validate credentials for a `List[User]`.
+ *
+ * Enter `Traverse`.
+ *
+ * = The type class =
+ * At center stage of `Traverse` is the `traverse` method.
+ *
+ * {{{
+ * trait Traverse[F[_]] {
+ * def traverse[G[_] : Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
+ * }
+ * }}}
+ *
+ * In our above example, `F` is `List`, and `G` is `Option`, `Xor`, or `Future`. For the profile example,
+ * `traverse` says given a `List[User]` and a function `User => Future[Profile]`, it can give you a
+ * `Future[List[Profile]]`.
+ *
+ * Abstracting away the `G` (still imagining `F` to be `List`), `traverse` says given a collection of data,
+ * and a function that takes a piece of data and returns an effectful value, it will traverse the collection,
+ * applying the function and aggregating the effectful values (in a `List`) as it goes.
+ *
+ * In the most general form, `F[_]` is some sort of context which may contain a value (or several). While
+ * `List` tends to be among the most general cases, there also exist `Traverse` instances for `Option`,
+ * `Xor`, and `Validated` (among others).
+ *
+ * @param name traverse
+ */
 object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+
   /** == Choose your effect ==
-    *
-    * The type signature of `Traverse` appears highly abstract, and indeed it is - what `traverse` does as it
-    * walks the `F[A]` depends on the effect of the function. Let's see some examples where `F` is taken to be
-    * `List`.
-    *
-    * Note in the following code snippet we are using `traverseU` instead of `traverse`.
-    * `traverseU` is for all intents and purposes the same as `traverse`, but with some
-    * [[http://typelevel.org/blog/2013/09/11/using-scalaz-Unapply.html type-level trickery]]
-    * to allow it to infer the `Applicative[Xor[A, ?]]` and `Applicative[Validated[A, ?]]`
-    * instances - `scalac` has issues inferring the instances for data types that do not
-    * trivially satisfy the `F[_]` shape required by `Applicative`.
-    *
-    * {{{
-    * import cats.Semigroup
-    * import cats.data.{NonEmptyList, OneAnd, Validated, ValidatedNel, Xor}
-    * import cats.implicits._
-    *
-    * def parseIntXor(s: String): Xor[NumberFormatException, Int] =
-    * Xor.catchOnly[NumberFormatException](s.toInt)
-    *
-    * def parseIntValidated(s: String): ValidatedNel[NumberFormatException, Int] =
-    * Validated.catchOnly[NumberFormatException](s.toInt).toValidatedNel
-    * }}}
-    *
-    * We can now traverse structures that contain strings parsing them into integers
-    * and accumulating failures with `Xor`.
-    */
+   *
+   * The type signature of `Traverse` appears highly abstract, and indeed it is - what `traverse` does as it
+   * walks the `F[A]` depends on the effect of the function. Let's see some examples where `F` is taken to be
+   * `List`.
+   *
+   * Note in the following code snippet we are using `traverseU` instead of `traverse`.
+   * `traverseU` is for all intents and purposes the same as `traverse`, but with some
+   * [[http://typelevel.org/blog/2013/09/11/using-scalaz-Unapply.html type-level trickery]]
+   * to allow it to infer the `Applicative[Xor[A, ?]]` and `Applicative[Validated[A, ?]]`
+   * instances - `scalac` has issues inferring the instances for data types that do not
+   * trivially satisfy the `F[_]` shape required by `Applicative`.
+   *
+   * {{{
+   * import cats.Semigroup
+   * import cats.data.{NonEmptyList, OneAnd, Validated, ValidatedNel, Xor}
+   * import cats.implicits._
+   *
+   * def parseIntXor(s: String): Xor[NumberFormatException, Int] =
+   * Xor.catchOnly[NumberFormatException](s.toInt)
+   *
+   * def parseIntValidated(s: String): ValidatedNel[NumberFormatException, Int] =
+   * Validated.catchOnly[NumberFormatException](s.toInt).toValidatedNel
+   * }}}
+   *
+   * We can now traverse structures that contain strings parsing them into integers
+   * and accumulating failures with `Xor`.
+   */
   def traverseuFunction(res0: List[Int], res1: Boolean) = {
     List("1", "2", "3").traverseU(parseIntXor) should be(Xor.Right(res0))
     List("1", "abc", "3").traverseU(parseIntXor).isLeft should be(res1)
   }
 
   /** We need proof that `NonEmptyList[A]` is a `Semigroup `for there to be an `Applicative` instance for
-    * `ValidatedNel`.
-    *
-    * {{{
-    *     implicit def nelSemigroup[A]: Semigroup[NonEmptyList[A]] =
-    *       OneAnd.oneAndSemigroupK[List].algebra[A]
-    * }}}
-    *
-    * Now that we've provided such evidence, we can use `ValidatedNel` as an applicative.
-    */
+   * `ValidatedNel`.
+   *
+   * {{{
+   *     implicit def nelSemigroup[A]: Semigroup[NonEmptyList[A]] =
+   *       OneAnd.oneAndSemigroupK[List].algebra[A]
+   * }}}
+   *
+   * Now that we've provided such evidence, we can use `ValidatedNel` as an applicative.
+   */
   def traverseuValidated(res0: Boolean) = {
     import cats.Semigroup
-    import cats.data.{ NonEmptyList, OneAnd, ValidatedNel }
+    import cats.data.{NonEmptyList, OneAnd, ValidatedNel}
 
     List("1", "2", "3").traverseU(parseIntValidated).isValid should be(res0)
   }
 
   /** Notice that in the `Xor` case, should any string fail to parse the entire traversal
-    * is considered a failure. Moreover, once it hits its first bad parse, it will not
-    * attempt to parse any others down the line (similar behavior would be found with
-    * using `Option` as the effect). Contrast this with `Validated` where even
-    * if one bad parse is hit, it will continue trying to parse the others, accumulating
-    * any and all errors as it goes. The behavior of traversal is closely tied with the
-    * `Applicative` behavior of the data type.
-    *
-    * Going back to our `Future` example, we can write an `Applicative` instance for
-    * `Future` that runs each `Future` concurrently. Then when we traverse a `List[A]`
-    * with an `A => Future[B]`, we can imagine the traversal as a scatter-gather.
-    * Each `A` creates a concurrent computation that will produce a `B` (the scatter),
-    * and as the `Future`s complete they will be gathered back into a `List`.
-    *
-    * == Playing with `Reader` ==
-    *
-    * Another interesting effect we can use is `Reader`. Recall that a `Reader[E, A]` is
-    * a type alias for `Kleisli[Id, E, A]` which is a wrapper around `E => A`.
-    *
-    * If we fix `E` to be some sort of environment or configuration, we can use the
-    * `Reader` applicative in our traverse.
-    *
-    * {{{
-    * import cats.data.Reader
-    *
-    * trait Context
-    * trait Topic
-    * trait Result
-    *
-    * type Job[A] = Reader[Context, A]
-    *
-    * def processTopic(topic: Topic): Job[Result] = ???
-    * }}}
-    *
-    * We can imagine we have a data pipeline that processes a bunch of data, each piece of data
-    * being categorized by a topic. Given a specific topic, we produce a `Job` that processes
-    * that topic. (Note that since a `Job` is just a `Reader`/`Kleisli`, one could write many small
-    * `Job`s and compose them together into one `Job` that is used/returned by `processTopic`.)
-    *
-    * Corresponding to our bunches of data are bunches of topics, a `List[Topic]` if you will.
-    * Since `Reader` has an `Applicative` instance, we can `traverse` over this list with `processTopic`.
-    *
-    * {{{
-    * def processTopics(topics: List[Topic]) =
-    * topics.traverse(processTopic)
-    * }}}
-    *
-    * Note the nice return type - `Job[List[Result]]`. We now have one aggregate `Job` that when run,
-    * will go through each topic and run the topic-specific job, collecting results as it goes.
-    * We say "when run" because a `Job` is some function that requires a `Context` before producing
-    * the value we want.
-    *
-    * One example of a "context" can be found in the [[http://spark.apache.org/ Spark]] project. In
-    * Spark, information needed to run a Spark job (where the master node is, memory allocated, etc.)
-    * resides in a `SparkContext`. Going back to the above example, we can see how one may define
-    * topic-specific Spark jobs (`type Job[A] = Reader[SparkContext, A]`) and then run several
-    * Spark jobs on a collection of topics via `traverse`. We then get back a `Job[List[Result]]`,
-    * which is equivalent to `SparkContext => List[Result]`. When finally passed a `SparkContext`,
-    * we can run the job and get our results back.
-    *
-    * Moreover, the fact that our aggregate job is not tied to any specific `SparkContext` allows us
-    * to pass in a `SparkContext` pointing to a production cluster, or (using the exact same job) pass
-    * in a test `SparkContext` that just runs locally across threads. This makes testing our large
-    * job nice and easy.
-    *
-    * Finally, this encoding ensures that all the jobs for each topic run on the exact same cluster.
-    * At no point do we manually pass in or thread a `SparkContext` through - that is taken care for us
-    * by the (applicative) effect of `Reader` and therefore by `traverse`.
-    *
-    * = Sequencing =
-    *
-    * Sometimes you may find yourself with a collection of data, each of which is already in an effect,
-    * for instance a `List[Option[A]]`. To make this easier to work with, you want a `Option[List[A]]`.
-    * Given `Option` has an `Applicative` instance, we can traverse over the list with the identity function.
-    *
-    */
+   * is considered a failure. Moreover, once it hits its first bad parse, it will not
+   * attempt to parse any others down the line (similar behavior would be found with
+   * using `Option` as the effect). Contrast this with `Validated` where even
+   * if one bad parse is hit, it will continue trying to parse the others, accumulating
+   * any and all errors as it goes. The behavior of traversal is closely tied with the
+   * `Applicative` behavior of the data type.
+   *
+   * Going back to our `Future` example, we can write an `Applicative` instance for
+   * `Future` that runs each `Future` concurrently. Then when we traverse a `List[A]`
+   * with an `A => Future[B]`, we can imagine the traversal as a scatter-gather.
+   * Each `A` creates a concurrent computation that will produce a `B` (the scatter),
+   * and as the `Future`s complete they will be gathered back into a `List`.
+   *
+   * == Playing with `Reader` ==
+   *
+   * Another interesting effect we can use is `Reader`. Recall that a `Reader[E, A]` is
+   * a type alias for `Kleisli[Id, E, A]` which is a wrapper around `E => A`.
+   *
+   * If we fix `E` to be some sort of environment or configuration, we can use the
+   * `Reader` applicative in our traverse.
+   *
+   * {{{
+   * import cats.data.Reader
+   *
+   * trait Context
+   * trait Topic
+   * trait Result
+   *
+   * type Job[A] = Reader[Context, A]
+   *
+   * def processTopic(topic: Topic): Job[Result] = ???
+   * }}}
+   *
+   * We can imagine we have a data pipeline that processes a bunch of data, each piece of data
+   * being categorized by a topic. Given a specific topic, we produce a `Job` that processes
+   * that topic. (Note that since a `Job` is just a `Reader`/`Kleisli`, one could write many small
+   * `Job`s and compose them together into one `Job` that is used/returned by `processTopic`.)
+   *
+   * Corresponding to our bunches of data are bunches of topics, a `List[Topic]` if you will.
+   * Since `Reader` has an `Applicative` instance, we can `traverse` over this list with `processTopic`.
+   *
+   * {{{
+   * def processTopics(topics: List[Topic]) =
+   * topics.traverse(processTopic)
+   * }}}
+   *
+   * Note the nice return type - `Job[List[Result]]`. We now have one aggregate `Job` that when run,
+   * will go through each topic and run the topic-specific job, collecting results as it goes.
+   * We say "when run" because a `Job` is some function that requires a `Context` before producing
+   * the value we want.
+   *
+   * One example of a "context" can be found in the [[http://spark.apache.org/ Spark]] project. In
+   * Spark, information needed to run a Spark job (where the master node is, memory allocated, etc.)
+   * resides in a `SparkContext`. Going back to the above example, we can see how one may define
+   * topic-specific Spark jobs (`type Job[A] = Reader[SparkContext, A]`) and then run several
+   * Spark jobs on a collection of topics via `traverse`. We then get back a `Job[List[Result]]`,
+   * which is equivalent to `SparkContext => List[Result]`. When finally passed a `SparkContext`,
+   * we can run the job and get our results back.
+   *
+   * Moreover, the fact that our aggregate job is not tied to any specific `SparkContext` allows us
+   * to pass in a `SparkContext` pointing to a production cluster, or (using the exact same job) pass
+   * in a test `SparkContext` that just runs locally across threads. This makes testing our large
+   * job nice and easy.
+   *
+   * Finally, this encoding ensures that all the jobs for each topic run on the exact same cluster.
+   * At no point do we manually pass in or thread a `SparkContext` through - that is taken care for us
+   * by the (applicative) effect of `Reader` and therefore by `traverse`.
+   *
+   * = Sequencing =
+   *
+   * Sometimes you may find yourself with a collection of data, each of which is already in an effect,
+   * for instance a `List[Option[A]]`. To make this easier to work with, you want a `Option[List[A]]`.
+   * Given `Option` has an `Applicative` instance, we can traverse over the list with the identity function.
+   *
+   */
   def sequencing(res0: Option[List[Int]], res1: Option[List[Int]]) = {
     import cats.implicits._
 
@@ -215,40 +221,40 @@ object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.de
   }
 
   /** `Traverse` provides a convenience method `sequence` that does exactly this.
-    *
-    * {{{
-    * List(Option(1), Option(2), Option(3)).sequence
-    * List(Option(1), None, Option(3)).sequence
-    * }}}
-    *
-    * = Traversing for effect =
-    *
-    * Sometimes our effectful functions return a `Unit` value in cases where there is no interesting value
-    * to return (e.g. writing to some sort of store).
-    *
-    * {{{
-    * trait Data
-    * def writeToStore(data: Data): Future[Unit] = ???
-    * }}}
-    *
-    * If we traverse using this, we end up with a funny type.
-    *
-    * {{{
-    * import cats.implicits._
-    * import scala.concurrent.ExecutionContext.Implicits.global
-    *
-    * def writeManyToStore(data: List[Data]) =
-    * data.traverse(writeToStore)
-    * }}}
-    *
-    * We end up with a `Future[List[Unit]]`! A `List[Unit]` is not of any use to us, and communicates the
-    * same amount of information as a single `Unit` does.
-    *
-    * Traversing solely for the sake of the effect (ignoring any values that may be produced, `Unit` or otherwise)
-    * is common, so `Foldable` (superclass of `Traverse`) provides `traverse_` and `sequence_` methods that do the
-    * same thing as `traverse` and `sequence` but ignores any value produced along the way, returning `Unit` at the end.
-    *
-    */
+   *
+   * {{{
+   * List(Option(1), Option(2), Option(3)).sequence
+   * List(Option(1), None, Option(3)).sequence
+   * }}}
+   *
+   * = Traversing for effect =
+   *
+   * Sometimes our effectful functions return a `Unit` value in cases where there is no interesting value
+   * to return (e.g. writing to some sort of store).
+   *
+   * {{{
+   * trait Data
+   * def writeToStore(data: Data): Future[Unit] = ???
+   * }}}
+   *
+   * If we traverse using this, we end up with a funny type.
+   *
+   * {{{
+   * import cats.implicits._
+   * import scala.concurrent.ExecutionContext.Implicits.global
+   *
+   * def writeManyToStore(data: List[Data]) =
+   * data.traverse(writeToStore)
+   * }}}
+   *
+   * We end up with a `Future[List[Unit]]`! A `List[Unit]` is not of any use to us, and communicates the
+   * same amount of information as a single `Unit` does.
+   *
+   * Traversing solely for the sake of the effect (ignoring any values that may be produced, `Unit` or otherwise)
+   * is common, so `Foldable` (superclass of `Traverse`) provides `traverse_` and `sequence_` methods that do the
+   * same thing as `traverse` and `sequence` but ignores any value produced along the way, returning `Unit` at the end.
+   *
+   */
   def traversingForEffects(res0: Option[Unit], res1: Option[Unit]) = {
     import cats.implicits._
 

--- a/src/main/scala/catslib/TraverseHelpers.scala
+++ b/src/main/scala/catslib/TraverseHelpers.scala
@@ -1,8 +1,13 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 object TraverseHelpers {
   import cats.Semigroup
-  import cats.data.{ NonEmptyList, OneAnd, Validated, ValidatedNel, Xor }
+  import cats.data.{NonEmptyList, OneAnd, Validated, ValidatedNel, Xor}
   import cats.implicits._
 
   def parseIntXor(s: String): Xor[NumberFormatException, Int] =

--- a/src/main/scala/catslib/Validated.scala
+++ b/src/main/scala/catslib/Validated.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -9,162 +14,166 @@ import cats.data.Xor
 import ValidatedHelpers._
 
 /** Imagine you are filling out a web form to sign up for an account. You input your username and password and submit.
-  * Response comes back saying your username can't have dashes in it, so you make some changes and resubmit. Can't
-  * have special characters either. Change, resubmit. Passwords need to have at least one capital letter. Change,
-  * resubmit. Password needs to have at least one number.
-  *
-  * Or perhaps you're reading from a configuration file. One could imagine the configuration library you're using returns
-  * a `scala.util.Try`, or maybe a `scala.util.Either` (or `cats.data.Xor`). Your parsing may look something like:
-  *
-  * {{{
-  * case class ConnectionParams(url: String, port: Int)
-  *
-  * for {
-  * url  <- config[String]("url")
-  * port <- config[Int]("port")
-  * } yield ConnectionParams(url, port)
-  * }}}
-  *
-  * You run your program and it says key "url" not found, turns out the key was "endpoint". So you change your code
-  * and re-run. Now it says the "port" key was not a well-formed integer.
-  *
-  * It would be nice to have all of these errors reported simultaneously. That the username can't have dashes can
-  * be validated separately from it not having special characters, as well as from the password needing to have certain
-  * requirements. A misspelled (or missing) field in a config can be validated separately from another field not being
-  * well-formed.
-  *
-  * Enter `Validated`.
-  *
-  * = Parallel validation =
-  *
-  * Our goal is to report any and all errors across independent bits of data. For instance, when we ask for several
-  * pieces of configuration, each configuration field can be validated separately from one another. How then do we
-  * enforce that the data we are working with is independent? We ask for both of them up front.
-  *
-  * As our running example, we will look at config parsing. Our config will be represented by a
-  * `Map[String, String]`. Parsing will be handled by a `Read` type class - we provide instances
-  * only for `String` and `Int` for brevity.
-  *
-  * {{{
-  * trait Read[A] {
-  * def read(s: String): Option[A]
-  * }
-  *
-  * object Read {
-  * def apply[A](implicit A: Read[A]): Read[A] = A
-  *
-  * implicit val stringRead: Read[String] =
-  *  new Read[String] { def read(s: String): Option[String] = Some(s) }
-  *
-  * implicit val intRead: Read[Int] =
-  *  new Read[Int] {
-  *    def read(s: String): Option[Int] =
-  *      if (s.matches("-?[0-9]+")) Some(s.toInt)
-  *      else None
-  *  }
-  * }
-  * }}}
-  *
-  * Then we enumerate our errors—when asking for a config value, one of two things can
-  * go wrong: the field is missing, or it is not well-formed with regards to the expected
-  * type.
-  *
-  * {{{
-  * sealed abstract class ConfigError
-  * final case class MissingConfig(field: String) extends ConfigError
-  * final case class ParseError(field: String) extends ConfigError
-  * }}}
-  *
-  * We need a data type that can represent either a successful value (a parsed configuration),
-  * or an error. It would look like the following, which cats provides in `cats.data.Validated`:
-  *
-  * {{{
-  * sealed abstract class Validated[+E, +A]
-  *
-  * object Validated {
-  * final case class Valid[+A](a: A) extends Validated[Nothing, A]
-  * final case class Invalid[+E](e: E) extends Validated[E, Nothing]
-  * }
-  * }}}
-  *
-  * Now we are ready to write our parser.
-  *
-  * {{{
-  * import cats.data.Validated
-  * import cats.data.Validated.{Invalid, Valid}
-  *
-  * case class Config(map: Map[String, String]) {
-  * def parse[A : Read](key: String): Validated[ConfigError, A] =
-  *  map.get(key) match {
-  *    case None        => Invalid(MissingConfig(key))
-  *    case Some(value) =>
-  *      Read[A].read(value) match {
-  *        case None    => Invalid(ParseError(key))
-  *        case Some(a) => Valid(a)
-  *      }
-  *  }
-  * }
-  * }}}
-  *
-  * Everything is in place to write the parallel validator. Recall that we can only do parallel
-  * validation if each piece is independent. How do we enforce the data is independent? By asking
-  * for all of it up front. Let's start with two pieces of data.
-  *
-  * {{{
-  * def parallelValidate[E, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
-  * (v1, v2) match {
-  *  case (Valid(a), Valid(b))       => Valid(f(a, b))
-  *  case (Valid(_), i@Invalid(_))   => i
-  *  case (i@Invalid(_), Valid(_))   => i
-  *  case (Invalid(e1), Invalid(e2)) => ???
-  * }
-  * }}}
-  *
-  * We've run into a problem. In the case where both have errors, we want to report both. But we have
-  * no way of combining the two errors into one error! Perhaps we can put both errors into a `List`,
-  * but that seems needlessly specific—clients may want to define their own way of combining errors.
-  *
-  * How then do we abstract over a binary operation? The `Semigroup` type class captures this idea.
-  *
-  * {{{
-  * import cats.Semigroup
-  *
-  * def parallelValidate[E : Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
-  * (v1, v2) match {
-  *  case (Valid(a), Valid(b))       => Valid(f(a, b))
-  *  case (Valid(_), i@Invalid(_))   => i
-  *  case (i@Invalid(_), Valid(_))   => i
-  *  case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
-  * }
-  * }}}
-  *
-  * Perfect! But, going back to our example, we don't have a way to combine `ConfigError`s. But as clients,
-  * we can change our `Validated` values where the error can be combined, say, a `List[ConfigError]`. It is
-  * more common however to use a `NonEmptyList[ConfigError]`—the `NonEmptyList` statically guarantees we
-  * have at least one value, which aligns with the fact that if we have an `Invalid`, then we most
-  * certainly have at least one error. This technique is so common there is a convenient method on `Validated`
-  * called `toValidatedNel` that turns any `Validated[E, A]` value to a `Validated[NonEmptyList[E], A]`.
-  * Additionally, the type alias `ValidatedNel[E, A]` is provided.
-  *
-  * Time to parse.
-  *
-  * {{{
-  * import cats.SemigroupK
-  * import cats.data.NonEmptyList
-  * import cats.implicits._
-  *
-  * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
-  * SemigroupK[NonEmptyList].algebra[ConfigError]
-  *
-  * implicit val readString: Read[String] = Read.stringRead
-  * implicit val readInt: Read[Int] = Read.intRead
-  * }}}
-  *
-  * @param name validated
-  */
-object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ * Response comes back saying your username can't have dashes in it, so you make some changes and resubmit. Can't
+ * have special characters either. Change, resubmit. Passwords need to have at least one capital letter. Change,
+ * resubmit. Password needs to have at least one number.
+ *
+ * Or perhaps you're reading from a configuration file. One could imagine the configuration library you're using returns
+ * a `scala.util.Try`, or maybe a `scala.util.Either` (or `cats.data.Xor`). Your parsing may look something like:
+ *
+ * {{{
+ * case class ConnectionParams(url: String, port: Int)
+ *
+ * for {
+ * url  <- config[String]("url")
+ * port <- config[Int]("port")
+ * } yield ConnectionParams(url, port)
+ * }}}
+ *
+ * You run your program and it says key "url" not found, turns out the key was "endpoint". So you change your code
+ * and re-run. Now it says the "port" key was not a well-formed integer.
+ *
+ * It would be nice to have all of these errors reported simultaneously. That the username can't have dashes can
+ * be validated separately from it not having special characters, as well as from the password needing to have certain
+ * requirements. A misspelled (or missing) field in a config can be validated separately from another field not being
+ * well-formed.
+ *
+ * Enter `Validated`.
+ *
+ * = Parallel validation =
+ *
+ * Our goal is to report any and all errors across independent bits of data. For instance, when we ask for several
+ * pieces of configuration, each configuration field can be validated separately from one another. How then do we
+ * enforce that the data we are working with is independent? We ask for both of them up front.
+ *
+ * As our running example, we will look at config parsing. Our config will be represented by a
+ * `Map[String, String]`. Parsing will be handled by a `Read` type class - we provide instances
+ * only for `String` and `Int` for brevity.
+ *
+ * {{{
+ * trait Read[A] {
+ * def read(s: String): Option[A]
+ * }
+ *
+ * object Read {
+ * def apply[A](implicit A: Read[A]): Read[A] = A
+ *
+ * implicit val stringRead: Read[String] =
+ *  new Read[String] { def read(s: String): Option[String] = Some(s) }
+ *
+ * implicit val intRead: Read[Int] =
+ *  new Read[Int] {
+ *    def read(s: String): Option[Int] =
+ *      if (s.matches("-?[0-9]+")) Some(s.toInt)
+ *      else None
+ *  }
+ * }
+ * }}}
+ *
+ * Then we enumerate our errors—when asking for a config value, one of two things can
+ * go wrong: the field is missing, or it is not well-formed with regards to the expected
+ * type.
+ *
+ * {{{
+ * sealed abstract class ConfigError
+ * final case class MissingConfig(field: String) extends ConfigError
+ * final case class ParseError(field: String) extends ConfigError
+ * }}}
+ *
+ * We need a data type that can represent either a successful value (a parsed configuration),
+ * or an error. It would look like the following, which cats provides in `cats.data.Validated`:
+ *
+ * {{{
+ * sealed abstract class Validated[+E, +A]
+ *
+ * object Validated {
+ * final case class Valid[+A](a: A) extends Validated[Nothing, A]
+ * final case class Invalid[+E](e: E) extends Validated[E, Nothing]
+ * }
+ * }}}
+ *
+ * Now we are ready to write our parser.
+ *
+ * {{{
+ * import cats.data.Validated
+ * import cats.data.Validated.{Invalid, Valid}
+ *
+ * case class Config(map: Map[String, String]) {
+ * def parse[A : Read](key: String): Validated[ConfigError, A] =
+ *  map.get(key) match {
+ *    case None        => Invalid(MissingConfig(key))
+ *    case Some(value) =>
+ *      Read[A].read(value) match {
+ *        case None    => Invalid(ParseError(key))
+ *        case Some(a) => Valid(a)
+ *      }
+ *  }
+ * }
+ * }}}
+ *
+ * Everything is in place to write the parallel validator. Recall that we can only do parallel
+ * validation if each piece is independent. How do we enforce the data is independent? By asking
+ * for all of it up front. Let's start with two pieces of data.
+ *
+ * {{{
+ * def parallelValidate[E, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
+ * (v1, v2) match {
+ *  case (Valid(a), Valid(b))       => Valid(f(a, b))
+ *  case (Valid(_), i@Invalid(_))   => i
+ *  case (i@Invalid(_), Valid(_))   => i
+ *  case (Invalid(e1), Invalid(e2)) => ???
+ * }
+ * }}}
+ *
+ * We've run into a problem. In the case where both have errors, we want to report both. But we have
+ * no way of combining the two errors into one error! Perhaps we can put both errors into a `List`,
+ * but that seems needlessly specific—clients may want to define their own way of combining errors.
+ *
+ * How then do we abstract over a binary operation? The `Semigroup` type class captures this idea.
+ *
+ * {{{
+ * import cats.Semigroup
+ *
+ * def parallelValidate[E : Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) => C): Validated[E, C] =
+ * (v1, v2) match {
+ *  case (Valid(a), Valid(b))       => Valid(f(a, b))
+ *  case (Valid(_), i@Invalid(_))   => i
+ *  case (i@Invalid(_), Valid(_))   => i
+ *  case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
+ * }
+ * }}}
+ *
+ * Perfect! But, going back to our example, we don't have a way to combine `ConfigError`s. But as clients,
+ * we can change our `Validated` values where the error can be combined, say, a `List[ConfigError]`. It is
+ * more common however to use a `NonEmptyList[ConfigError]`—the `NonEmptyList` statically guarantees we
+ * have at least one value, which aligns with the fact that if we have an `Invalid`, then we most
+ * certainly have at least one error. This technique is so common there is a convenient method on `Validated`
+ * called `toValidatedNel` that turns any `Validated[E, A]` value to a `Validated[NonEmptyList[E], A]`.
+ * Additionally, the type alias `ValidatedNel[E, A]` is provided.
+ *
+ * Time to parse.
+ *
+ * {{{
+ * import cats.SemigroupK
+ * import cats.data.NonEmptyList
+ * import cats.implicits._
+ *
+ * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
+ * SemigroupK[NonEmptyList].algebra[ConfigError]
+ *
+ * implicit val readString: Read[String] = Read.stringRead
+ * implicit val readInt: Read[Int] = Read.intRead
+ * }}}
+ *
+ * @param name validated
+ */
+object ValidatedSection
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
+
   /** When no errors are present in the configuration, we get a `ConnectionParams` wrapped in a `Valid` instance.
-    */
+   */
   def noErrors(res0: Boolean, res1: String, res2: Int) = {
     val config = Config(Map(("url", "127.0.0.1"), ("port", "1337")))
 
@@ -178,8 +187,8 @@ object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.d
   }
 
   /** But what happens when having one or more errors? They are accumulated in a `NonEmptyList`
-    * wrapped in an `Invalid` instance.
-    */
+   * wrapped in an `Invalid` instance.
+   */
   def someErrors(res0: Boolean, res1: Boolean) = {
     val config = Config(Map(("endpoint", "127.0.0.1"), ("port", "not a number")))
 
@@ -197,130 +206,130 @@ object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.d
   }
 
   /** = Apply =
-    *
-    * Our `parallelValidate` function looks awfully like the `Apply#map2` function.
-    *
-    * {{{
-    * def map2[F[_], A, B, C](fa: F[A], fb: F[B])(f: (A, B) => C): F[C]
-    * }}}
-    *
-    * Which can be defined in terms of `Apply#ap` and `Apply#map`, the very functions needed to create an `Apply` instance.
-    *
-    * Can we perhaps define an `Apply` instance for `Validated`? Better yet, can we define an `Applicative` instance?
-    *
-    * {{{
-    * import cats.Applicative
-    *
-    * implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, ?]] =
-    * new Applicative[Validated[E, ?]] {
-    *  def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
-    *    (fa, f) match {
-    *      case (Valid(a), Valid(fab)) => Valid(fab(a))
-    *      case (i@Invalid(_), Valid(_)) => i
-    *      case (Valid(_), i@Invalid(_)) => i
-    *      case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
-    *    }
-    *
-    *  def pure[A](x: A): Validated[E, A] = Validated.valid(x)
-    *  def map[A, B](fa: Validated[E, A])(f: A => B): Validated[E, B] = fa.map(f)
-    *  def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
-    *    ap(fa.map(a => (b: B) => (a, b)))(fb)
-    * }
-    * }}}
-    *
-    * Awesome! And now we also get access to all the goodness of `Applicative`, which includes `map{2-22}`, as well as the
-    * `Cartesian` syntax `|@|`.
-    *
-    * We can now easily ask for several bits of configuration and get any and all errors returned back.
-    *
-    * {{{
-    * import cats.Apply
-    * import cats.data.ValidatedNel
-    *
-    * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
-    * SemigroupK[NonEmptyList].algebra[ConfigError]
-    *
-    * val config = Config(Map(("name", "cat"), ("age", "not a number"), ("houseNumber", "1234"), ("lane", "feline street")))
-    *
-    * case class Address(houseNumber: Int, street: String)
-    * case class Person(name: String, age: Int, address: Address)
-    * }}}
-    *
-    * Thus.
-    *
-    * {{{
-    * val personFromConfig: ValidatedNel[ConfigError, Person] =
-    * Apply[ValidatedNel[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNel,
-    *                                         config.parse[Int]("age").toValidatedNel,
-    *                                         config.parse[Int]("house_number").toValidatedNel,
-    *                                         config.parse[String]("street").toValidatedNel) {
-    *  case (name, age, houseNumber, street) => Person(name, age, Address(houseNumber, street))
-    * }
-    * }}}
-    *
-    * We can now rewrite validations in terms of `Apply`.
-    *
-    * == Of `flatMap`s and `Xor`s ==
-    *
-    * `Option` has `flatMap`, `Xor` has `flatMap`, where's `Validated`'s? Let's try to implement it—better yet,
-    * let's implement the `Monad` type class.
-    *
-    * {{{
-    * import cats.Monad
-    *
-    * implicit def validatedMonad[E]: Monad[Validated[E, ?]] =
-    * new Monad[Validated[E, ?]] {
-    *  def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
-    *    fa match {
-    *      case Valid(a)     => f(a)
-    *      case i@Invalid(_) => i
-    *    }
-    *
-    *  def pure[A](x: A): Validated[E, A] = Valid(x)
-    * }
-    * }}}
-    *
-    * Note that all `Monad` instances are also `Applicative` instances, where `ap` is defined as
-    *
-    * {{{
-    * trait Monad[F[_]] {
-    * def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
-    * def pure[A](x: A): F[A]
-    *
-    * def map[A, B](fa: F[A])(f: A => B): F[B] =
-    *  flatMap(fa)(f.andThen(pure))
-    *
-    * def ap[A, B](fa: F[A])(f: F[A => B]): F[B] =
-    *  flatMap(fa)(a => map(f)(fab => fab(a)))
-    * }
-    * }}}
-    *
-    * However, the `ap` behavior defined in terms of `flatMap` does not behave the same as that of
-    * our `ap` defined above. Observe:
-    *
-    * {{{
-    * val v = validatedMonad.tuple2(Validated.invalidNel[String, Int]("oops"), Validated.invalidNel[String, Double]("uh oh"))
-    * }}}
-    *
-    * This one short circuits! Therefore, if we were to define a `Monad` (or `FlatMap`) instance for `Validated` we would
-    * have to override `ap` to get the behavior we want. But then the behavior of `flatMap` would be inconsistent with
-    * that of `ap`, not good. Therefore, `Validated` has only an `Applicative` instance.
-    *
-    * = Sequential Validation =
-    *
-    * If you do want error accumulation but occasionally run into places where sequential validation is needed, then `Validated` provides a couple methods that may be helpful.
-    *
-    * == `andThen` ===
-    *
-    * The `andThen` method is similar to `flatMap` (such as `Xor.flatMap`). In the case of success, it passes the valid value into a function that returns a new `Validated` instance.
-    *
-    * {{{
-    * val houseNumber = config.parse[Int]("house_number").andThen{ n =>
-    * if (n >= 0) Validated.valid(n)
-    * else Validated.invalid(ParseError("house_number"))
-    * }
-    * }}}
-    */
+   *
+   * Our `parallelValidate` function looks awfully like the `Apply#map2` function.
+   *
+   * {{{
+   * def map2[F[_], A, B, C](fa: F[A], fb: F[B])(f: (A, B) => C): F[C]
+   * }}}
+   *
+   * Which can be defined in terms of `Apply#ap` and `Apply#map`, the very functions needed to create an `Apply` instance.
+   *
+   * Can we perhaps define an `Apply` instance for `Validated`? Better yet, can we define an `Applicative` instance?
+   *
+   * {{{
+   * import cats.Applicative
+   *
+   * implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, ?]] =
+   * new Applicative[Validated[E, ?]] {
+   *  def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
+   *    (fa, f) match {
+   *      case (Valid(a), Valid(fab)) => Valid(fab(a))
+   *      case (i@Invalid(_), Valid(_)) => i
+   *      case (Valid(_), i@Invalid(_)) => i
+   *      case (Invalid(e1), Invalid(e2)) => Invalid(Semigroup[E].combine(e1, e2))
+   *    }
+   *
+   *  def pure[A](x: A): Validated[E, A] = Validated.valid(x)
+   *  def map[A, B](fa: Validated[E, A])(f: A => B): Validated[E, B] = fa.map(f)
+   *  def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
+   *    ap(fa.map(a => (b: B) => (a, b)))(fb)
+   * }
+   * }}}
+   *
+   * Awesome! And now we also get access to all the goodness of `Applicative`, which includes `map{2-22}`, as well as the
+   * `Cartesian` syntax `|@|`.
+   *
+   * We can now easily ask for several bits of configuration and get any and all errors returned back.
+   *
+   * {{{
+   * import cats.Apply
+   * import cats.data.ValidatedNel
+   *
+   * implicit val nelSemigroup: Semigroup[NonEmptyList[ConfigError]] =
+   * SemigroupK[NonEmptyList].algebra[ConfigError]
+   *
+   * val config = Config(Map(("name", "cat"), ("age", "not a number"), ("houseNumber", "1234"), ("lane", "feline street")))
+   *
+   * case class Address(houseNumber: Int, street: String)
+   * case class Person(name: String, age: Int, address: Address)
+   * }}}
+   *
+   * Thus.
+   *
+   * {{{
+   * val personFromConfig: ValidatedNel[ConfigError, Person] =
+   * Apply[ValidatedNel[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNel,
+   *                                         config.parse[Int]("age").toValidatedNel,
+   *                                         config.parse[Int]("house_number").toValidatedNel,
+   *                                         config.parse[String]("street").toValidatedNel) {
+   *  case (name, age, houseNumber, street) => Person(name, age, Address(houseNumber, street))
+   * }
+   * }}}
+   *
+   * We can now rewrite validations in terms of `Apply`.
+   *
+   * == Of `flatMap`s and `Xor`s ==
+   *
+   * `Option` has `flatMap`, `Xor` has `flatMap`, where's `Validated`'s? Let's try to implement it—better yet,
+   * let's implement the `Monad` type class.
+   *
+   * {{{
+   * import cats.Monad
+   *
+   * implicit def validatedMonad[E]: Monad[Validated[E, ?]] =
+   * new Monad[Validated[E, ?]] {
+   *  def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
+   *    fa match {
+   *      case Valid(a)     => f(a)
+   *      case i@Invalid(_) => i
+   *    }
+   *
+   *  def pure[A](x: A): Validated[E, A] = Valid(x)
+   * }
+   * }}}
+   *
+   * Note that all `Monad` instances are also `Applicative` instances, where `ap` is defined as
+   *
+   * {{{
+   * trait Monad[F[_]] {
+   * def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+   * def pure[A](x: A): F[A]
+   *
+   * def map[A, B](fa: F[A])(f: A => B): F[B] =
+   *  flatMap(fa)(f.andThen(pure))
+   *
+   * def ap[A, B](fa: F[A])(f: F[A => B]): F[B] =
+   *  flatMap(fa)(a => map(f)(fab => fab(a)))
+   * }
+   * }}}
+   *
+   * However, the `ap` behavior defined in terms of `flatMap` does not behave the same as that of
+   * our `ap` defined above. Observe:
+   *
+   * {{{
+   * val v = validatedMonad.tuple2(Validated.invalidNel[String, Int]("oops"), Validated.invalidNel[String, Double]("uh oh"))
+   * }}}
+   *
+   * This one short circuits! Therefore, if we were to define a `Monad` (or `FlatMap`) instance for `Validated` we would
+   * have to override `ap` to get the behavior we want. But then the behavior of `flatMap` would be inconsistent with
+   * that of `ap`, not good. Therefore, `Validated` has only an `Applicative` instance.
+   *
+   * = Sequential Validation =
+   *
+   * If you do want error accumulation but occasionally run into places where sequential validation is needed, then `Validated` provides a couple methods that may be helpful.
+   *
+   * == `andThen` ===
+   *
+   * The `andThen` method is similar to `flatMap` (such as `Xor.flatMap`). In the case of success, it passes the valid value into a function that returns a new `Validated` instance.
+   *
+   * {{{
+   * val houseNumber = config.parse[Int]("house_number").andThen{ n =>
+   * if (n >= 0) Validated.valid(n)
+   * else Validated.invalid(ParseError("house_number"))
+   * }
+   * }}}
+   */
   def sequentialValidation(res0: Boolean, res1: Boolean) = {
     val config = Config(Map("house_number" → "-42"))
 
@@ -335,21 +344,21 @@ object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.d
   }
 
   /** == `withXor` ==
-    *
-    * The `withXor` method allows you to temporarily turn a `Validated` instance into an `Xor` instance and apply it to a function.
-    *
-    * {{{
-    * import cats.data.Xor
-    *
-    * def positive(field: String, i: Int): ConfigError Xor Int = {
-    * if (i >= 0) Xor.right(i)
-    * else Xor.left(ParseError(field))
-    * }
-    * }}}
-    *
-    * So we can get `Xor`'s short-circuiting behaviour when using the `Validated` type.
-    *
-    */
+   *
+   * The `withXor` method allows you to temporarily turn a `Validated` instance into an `Xor` instance and apply it to a function.
+   *
+   * {{{
+   * import cats.data.Xor
+   *
+   * def positive(field: String, i: Int): ConfigError Xor Int = {
+   * if (i >= 0) Xor.right(i)
+   * else Xor.left(ParseError(field))
+   * }
+   * }}}
+   *
+   * So we can get `Xor`'s short-circuiting behaviour when using the `Validated` type.
+   *
+   */
   def validatedAsXor(res0: Boolean, res1: Boolean) = {
     val config = Config(Map("house_number" → "-42"))
 

--- a/src/main/scala/catslib/ValidatedHelpers.scala
+++ b/src/main/scala/catslib/ValidatedHelpers.scala
@@ -1,9 +1,14 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
-import cats.{ Semigroup, SemigroupK }
+import cats.{Semigroup, SemigroupK}
 import cats.data.NonEmptyList
 import cats.data.Validated
-import cats.data.Validated.{ Invalid, Valid }
+import cats.data.Validated.{Invalid, Valid}
 import cats.data.Xor
 import cats.implicits._
 
@@ -30,10 +35,10 @@ object ValidatedHelpers {
 
   sealed abstract class ConfigError
   final case class MissingConfig(field: String) extends ConfigError
-  final case class ParseError(field: String) extends ConfigError
+  final case class ParseError(field: String)    extends ConfigError
 
   import cats.data.Validated
-  import cats.data.Validated.{ Invalid, Valid }
+  import cats.data.Validated.{Invalid, Valid}
 
   case class Config(map: Map[String, String]) {
     def parse[A: Read](key: String): Validated[ConfigError, A] =
@@ -49,7 +54,8 @@ object ValidatedHelpers {
 
   import cats.Semigroup
 
-  def parallelValidate[E: Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(f: (A, B) ⇒ C): Validated[E, C] =
+  def parallelValidate[E: Semigroup, A, B, C](v1: Validated[E, A], v2: Validated[E, B])(
+      f: (A, B) ⇒ C): Validated[E, C] =
     (v1, v2) match {
       case (Valid(a), Valid(b))       ⇒ Valid(f(a, b))
       case (Valid(_), i @ Invalid(_)) ⇒ i
@@ -65,7 +71,7 @@ object ValidatedHelpers {
     SemigroupK[NonEmptyList].algebra[ConfigError]
 
   implicit val readString: Read[String] = Read.stringRead
-  implicit val readInt: Read[Int] = Read.intRead
+  implicit val readInt: Read[Int]       = Read.intRead
 
   def positive(field: String, i: Int): ConfigError Xor Int = {
     if (i >= 0) Xor.right(i)

--- a/src/main/scala/catslib/XorSection.scala
+++ b/src/main/scala/catslib/XorSection.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalatest._
@@ -22,7 +27,7 @@ object XorStyle {
 object XorStyleWithAdts {
   sealed abstract class Error
   final case class NotANumber(string: String) extends Error
-  final case object NoZeroReciprocal extends Error
+  final case object NoZeroReciprocal          extends Error
 
   def parse(s: String): Xor[Error, Int] =
     if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
@@ -39,82 +44,82 @@ object XorStyleWithAdts {
 }
 
 /** In day-to-day programming, it is fairly common to find ourselves writing functions that
-  * can fail. For instance, querying a service may result in a connection issue, or some
-  * unexpected JSON response.
-  *
-  * To communicate these errors it has become common practice to throw exceptions. However,
-  * exceptions are not tracked in any way, shape, or form by the Scala compiler. To see
-  * what kind of exceptions (if any) a function may throw, we have to dig through the source code.
-  * Then to handle these exceptions, we have to make sure we catch them at the call site.
-  * This all becomes even more unwieldy when we try to compose exception-throwing procedures.
-  *
-  * {{{
-  * val throwsSomeStuff: Int => Double = ???
-  *
-  * val throwsOtherThings: Double => String = ???
-  *
-  * val moreThrowing: String => List[Char] = ???
-  *
-  * val magic = throwsSomeStuff.andThen(throwsOtherThings).andThen(moreThrowing)
-  * }}}
-  *
-  * Assume we happily throw exceptions in our code. Looking at the types, any of those functions
-  * can throw any number of exceptions, we don't know. When we compose, exceptions from any of
-  * the constituent functions can be thrown. Moreover, they may throw the same kind of exception
-  * (e.g. `IllegalArgumentException`) and thus it gets tricky tracking exactly where that
-  * exception came from.
-  *
-  * How then do we communicate an error? By making it explicit in the data type we return.
-  *
-  * =`Xor` vs `Validated`=
-  *
-  * In general, `Validated` is used to accumulate errors, while `Xor` is used to short-circuit a computation upon the first error. For more information, see the `Validated` vs `Xor` section of the `Validated` documentation.
-  *
-  * =Why not `Either`=
-  *
-  * `Xor` is very similar to `scala.util.Either` - in fact, they are *isomorphic* (that is,
-  * any `Either` value can be rewritten as an `Xor` value, and vice versa).
-  *
-  * {{{
-  * sealed abstract class Xor[+A, +B]
-  *
-  * object Xor {
-  * final case class Left[+A](a: A) extends Xor[A, Nothing]
-  * final case class Right[+B](b: B) extends Xor[Nothing, B]
-  * }
-  * }}}
-  *
-  * Just like `Either`, it has two type parameters. Instances of `Xor` either hold a value
-  * of one type parameter, or the other. Why then does it exist at all?
-  *
-  * Taking a look at `Either`, we notice it lacks `flatMap` and `map` methods. In order to map
-  * over an `Either[A, B]` value, we have to state which side we want to map over. For example,
-  * if we want to map `Either[A, B]` to `Either[A, C]` we would need to map over the right side.
-  * This can be accomplished by using the `Either#right` method, which returns a `RightProjection`
-  * instance. `RightProjection` does have `flatMap` and `map` on it, which acts on the right side
-  * and ignores the left - this property is referred to as "right-bias."
-  *
-  * {{{
-  * val e1: Either[String, Int] = Right(5)
-  * e1.right.map(_ + 1)
-  *
-  * val e2: Either[String, Int] = Left("hello")
-  * e2.right.map(_ + 1)
-  * }}}
-  *
-  * Note the return types are themselves back to `Either`, so if we want to make more calls to
-  * `flatMap` or `map` then we again must call `right` or `left`.
-  *
-  * @param name xor
-  */
+ * can fail. For instance, querying a service may result in a connection issue, or some
+ * unexpected JSON response.
+ *
+ * To communicate these errors it has become common practice to throw exceptions. However,
+ * exceptions are not tracked in any way, shape, or form by the Scala compiler. To see
+ * what kind of exceptions (if any) a function may throw, we have to dig through the source code.
+ * Then to handle these exceptions, we have to make sure we catch them at the call site.
+ * This all becomes even more unwieldy when we try to compose exception-throwing procedures.
+ *
+ * {{{
+ * val throwsSomeStuff: Int => Double = ???
+ *
+ * val throwsOtherThings: Double => String = ???
+ *
+ * val moreThrowing: String => List[Char] = ???
+ *
+ * val magic = throwsSomeStuff.andThen(throwsOtherThings).andThen(moreThrowing)
+ * }}}
+ *
+ * Assume we happily throw exceptions in our code. Looking at the types, any of those functions
+ * can throw any number of exceptions, we don't know. When we compose, exceptions from any of
+ * the constituent functions can be thrown. Moreover, they may throw the same kind of exception
+ * (e.g. `IllegalArgumentException`) and thus it gets tricky tracking exactly where that
+ * exception came from.
+ *
+ * How then do we communicate an error? By making it explicit in the data type we return.
+ *
+ * =`Xor` vs `Validated`=
+ *
+ * In general, `Validated` is used to accumulate errors, while `Xor` is used to short-circuit a computation upon the first error. For more information, see the `Validated` vs `Xor` section of the `Validated` documentation.
+ *
+ * =Why not `Either`=
+ *
+ * `Xor` is very similar to `scala.util.Either` - in fact, they are *isomorphic* (that is,
+ * any `Either` value can be rewritten as an `Xor` value, and vice versa).
+ *
+ * {{{
+ * sealed abstract class Xor[+A, +B]
+ *
+ * object Xor {
+ * final case class Left[+A](a: A) extends Xor[A, Nothing]
+ * final case class Right[+B](b: B) extends Xor[Nothing, B]
+ * }
+ * }}}
+ *
+ * Just like `Either`, it has two type parameters. Instances of `Xor` either hold a value
+ * of one type parameter, or the other. Why then does it exist at all?
+ *
+ * Taking a look at `Either`, we notice it lacks `flatMap` and `map` methods. In order to map
+ * over an `Either[A, B]` value, we have to state which side we want to map over. For example,
+ * if we want to map `Either[A, B]` to `Either[A, C]` we would need to map over the right side.
+ * This can be accomplished by using the `Either#right` method, which returns a `RightProjection`
+ * instance. `RightProjection` does have `flatMap` and `map` on it, which acts on the right side
+ * and ignores the left - this property is referred to as "right-bias."
+ *
+ * {{{
+ * val e1: Either[String, Int] = Right(5)
+ * e1.right.map(_ + 1)
+ *
+ * val e2: Either[String, Int] = Left("hello")
+ * e2.right.map(_ + 1)
+ * }}}
+ *
+ * Note the return types are themselves back to `Either`, so if we want to make more calls to
+ * `flatMap` or `map` then we again must call `right` or `left`.
+ *
+ * @param name xor
+ */
 object XorSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** More often than not we want to just bias towards one side and call it a day - by convention,
-    * the right side is most often chosen. This is the primary difference between `Xor` and `Either` -
-    * `Xor` is right-biased. `Xor` also has some more convenient methods on it, but the most
-    * crucial one is the right-biased being built-in.
-    *
-    */
+   * the right side is most often chosen. This is the primary difference between `Xor` and `Either` -
+   * `Xor` is right-biased. `Xor` also has some more convenient methods on it, but the most
+   * crucial one is the right-biased being built-in.
+   *
+   */
   def xorMapRightBias(res0: String Xor Int, res1: String Xor Int) = {
     import cats.data.Xor
 
@@ -126,30 +131,30 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** Because `Xor` is right-biased, it is possible to define a `Monad` instance for it. You
-    * could also define one for `Either` but due to how it's encoded it may seem strange to fix a
-    * bias direction despite it intending to be flexible in that regard. The `Monad` instance for
-    * `Xor` is consistent with the behavior of the data type itself, whereas the one for `Either`
-    * would only introduce bias when `Either` is used in a generic context (a function abstracted
-    * over `M[_] : Monad`).
-    *
-    * Since we only ever want the computation to continue in the case of `Xor.Right` (as captured
-    * by the right-bias nature), we fix the left type parameter and leave the right one free.
-    *
-    * {{{
-    * import cats.Monad
-    *
-    * implicit def xorMonad[Err]: Monad[Xor[Err, ?]] =
-    * new Monad[Xor[Err, ?]] {
-    *  def flatMap[A, B](fa: Xor[Err, A])(f: A => Xor[Err, B]): Xor[Err, B] =
-    *    fa.flatMap(f)
-    *
-    *  def pure[A](x: A): Xor[Err, A] = Xor.right(x)
-    * }
-    * }}}
-    *
-    * So the `flatMap` method is right-biased:
-    *
-    */
+   * could also define one for `Either` but due to how it's encoded it may seem strange to fix a
+   * bias direction despite it intending to be flexible in that regard. The `Monad` instance for
+   * `Xor` is consistent with the behavior of the data type itself, whereas the one for `Either`
+   * would only introduce bias when `Either` is used in a generic context (a function abstracted
+   * over `M[_] : Monad`).
+   *
+   * Since we only ever want the computation to continue in the case of `Xor.Right` (as captured
+   * by the right-bias nature), we fix the left type parameter and leave the right one free.
+   *
+   * {{{
+   * import cats.Monad
+   *
+   * implicit def xorMonad[Err]: Monad[Xor[Err, ?]] =
+   * new Monad[Xor[Err, ?]] {
+   *  def flatMap[A, B](fa: Xor[Err, A])(f: A => Xor[Err, B]): Xor[Err, B] =
+   *    fa.flatMap(f)
+   *
+   *  def pure[A](x: A): Xor[Err, A] = Xor.right(x)
+   * }
+   * }}}
+   *
+   * So the `flatMap` method is right-biased:
+   *
+   */
   def xorMonad(res0: String Xor Int, res1: String Xor Int) = {
     import cats.data.Xor
 
@@ -161,57 +166,57 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** = Using `Xor` instead of exceptions =
-    *
-    * As a running example, we will have a series of functions that will parse a string into an integer,
-    * take the reciprocal, and then turn the reciprocal into a string.
-    *
-    * In exception-throwing code, we would have something like this:
-    *
-    * {{{
-    * object ExceptionStyle {
-    * def parse(s: String): Int =
-    *  if (s.matches("-?[0-9]+")) s.toInt
-    *  else throw new NumberFormatException(s"${s} is not a valid integer.")
-    *
-    * def reciprocal(i: Int): Double =
-    *  if (i == 0) throw new IllegalArgumentException("Cannot take reciprocal of 0.")
-    *  else 1.0 / i
-    *
-    * def stringify(d: Double): String = d.toString
-    *
-    * }
-    * }}}
-    *
-    * Instead, let's make the fact that some of our functions can fail explicit in the return type.
-    *
-    * {{{
-    * object XorStyle {
-    * def parse(s: String): Xor[NumberFormatException, Int] =
-    *  if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
-    *  else Xor.left(new NumberFormatException(s"${s} is not a valid integer."))
-    *
-    * def reciprocal(i: Int): Xor[IllegalArgumentException, Double] =
-    *  if (i == 0) Xor.left(new IllegalArgumentException("Cannot take reciprocal of 0."))
-    *  else Xor.right(1.0 / i)
-    *
-    * def stringify(d: Double): String = d.toString
-    *
-    * def magic(s: String): Xor[Exception, String] =
-    *  parse(s).flatMap(reciprocal).map(stringify)
-    * }
-    * }}}
-    *
-    * Do these calls return a `Xor.Right` value?
-    *
-    */
+   *
+   * As a running example, we will have a series of functions that will parse a string into an integer,
+   * take the reciprocal, and then turn the reciprocal into a string.
+   *
+   * In exception-throwing code, we would have something like this:
+   *
+   * {{{
+   * object ExceptionStyle {
+   * def parse(s: String): Int =
+   *  if (s.matches("-?[0-9]+")) s.toInt
+   *  else throw new NumberFormatException(s"${s} is not a valid integer.")
+   *
+   * def reciprocal(i: Int): Double =
+   *  if (i == 0) throw new IllegalArgumentException("Cannot take reciprocal of 0.")
+   *  else 1.0 / i
+   *
+   * def stringify(d: Double): String = d.toString
+   *
+   * }
+   * }}}
+   *
+   * Instead, let's make the fact that some of our functions can fail explicit in the return type.
+   *
+   * {{{
+   * object XorStyle {
+   * def parse(s: String): Xor[NumberFormatException, Int] =
+   *  if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
+   *  else Xor.left(new NumberFormatException(s"${s} is not a valid integer."))
+   *
+   * def reciprocal(i: Int): Xor[IllegalArgumentException, Double] =
+   *  if (i == 0) Xor.left(new IllegalArgumentException("Cannot take reciprocal of 0."))
+   *  else Xor.right(1.0 / i)
+   *
+   * def stringify(d: Double): String = d.toString
+   *
+   * def magic(s: String): Xor[Exception, String] =
+   *  parse(s).flatMap(reciprocal).map(stringify)
+   * }
+   * }}}
+   *
+   * Do these calls return a `Xor.Right` value?
+   *
+   */
   def xorStyleParse(res0: Boolean, res1: Boolean) = {
     XorStyle.parse("Not a number").isRight should be(res0)
     XorStyle.parse("2").isRight should be(res1)
   }
 
   /** Now, using combinators like `flatMap` and `map`, we can compose our functions together. Will the following incantations return a `Xor.Right` value?
-    *
-    */
+   *
+   */
   def xorComposition(res0: Boolean, res1: Boolean, res2: Boolean) = {
     import XorStyle._
 
@@ -221,18 +226,18 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** With the composite function that we actually care about, we can pass in strings and then pattern
-    * match on the exception. Because `Xor` is a sealed type (often referred to as an algebraic data type,
-    * or ADT), the compiler will complain if we do not check both the `Left` and `Right` case.
-    *
-    * In the following exercise we pattern-match on every case the `Xor` returned by `magic` can be in.
-    * If we leave out any of those clauses the compiler will yell at us, as it should. However,
-    * note the `Xor.Left(_)` clause - the compiler will complain if we leave that out because it knows
-    * that given the type `Xor[Exception, String]`, there can be inhabitants of `Xor.Left` that are not
-    * `NumberFormatException` or `IllegalArgumentException`. However, we "know" by inspection of the source
-    * that those will be the only exceptions thrown, so it seems strange to have to account for other exceptions.
-    * This implies that there is still room to improve.
-    *
-    */
+   * match on the exception. Because `Xor` is a sealed type (often referred to as an algebraic data type,
+   * or ADT), the compiler will complain if we do not check both the `Left` and `Right` case.
+   *
+   * In the following exercise we pattern-match on every case the `Xor` returned by `magic` can be in.
+   * If we leave out any of those clauses the compiler will yell at us, as it should. However,
+   * note the `Xor.Left(_)` clause - the compiler will complain if we leave that out because it knows
+   * that given the type `Xor[Exception, String]`, there can be inhabitants of `Xor.Left` that are not
+   * `NumberFormatException` or `IllegalArgumentException`. However, we "know" by inspection of the source
+   * that those will be the only exceptions thrown, so it seems strange to have to account for other exceptions.
+   * This implies that there is still room to improve.
+   *
+   */
   def xorExceptions(res0: String) = {
     import XorStyle._
 
@@ -246,35 +251,35 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** Instead of using exceptions as our error value, let's instead enumerate explicitly the things that
-    * can go wrong in our program.
-    *
-    * {{{
-    * object XorStyleWithAdts {
-    * sealed abstract class Error
-    * final case class NotANumber(string: String) extends Error
-    * final case object NoZeroReciprocal extends Error
-    *
-    * def parse(s: String): Xor[Error, Int] =
-    *  if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
-    *  else Xor.left(NotANumber(s))
-    *
-    * def reciprocal(i: Int): Xor[Error, Double] =
-    *  if (i == 0) Xor.left(NoZeroReciprocal)
-    *  else Xor.right(1.0 / i)
-    *
-    * def stringify(d: Double): String = d.toString
-    *
-    * def magic(s: String): Xor[Error, String] =
-    *  parse(s).flatMap(reciprocal).map(stringify)
-    * }
-    * }}}
-    *
-    * For our little module, we enumerate any and all errors that can occur. Then, instead of using
-    * exception classes as error values, we use one of the enumerated cases. Now when we pattern
-    * match, we get much nicer matching. Moreover, since `Error` is `sealed`, no outside code can
-    * add additional subtypes which we might fail to handle.
-    *
-    */
+   * can go wrong in our program.
+   *
+   * {{{
+   * object XorStyleWithAdts {
+   * sealed abstract class Error
+   * final case class NotANumber(string: String) extends Error
+   * final case object NoZeroReciprocal extends Error
+   *
+   * def parse(s: String): Xor[Error, Int] =
+   *  if (s.matches("-?[0-9]+")) Xor.right(s.toInt)
+   *  else Xor.left(NotANumber(s))
+   *
+   * def reciprocal(i: Int): Xor[Error, Double] =
+   *  if (i == 0) Xor.left(NoZeroReciprocal)
+   *  else Xor.right(1.0 / i)
+   *
+   * def stringify(d: Double): String = d.toString
+   *
+   * def magic(s: String): Xor[Error, String] =
+   *  parse(s).flatMap(reciprocal).map(stringify)
+   * }
+   * }}}
+   *
+   * For our little module, we enumerate any and all errors that can occur. Then, instead of using
+   * exception classes as error values, we use one of the enumerated cases. Now when we pattern
+   * match, we get much nicer matching. Moreover, since `Error` is `sealed`, no outside code can
+   * add additional subtypes which we might fail to handle.
+   *
+   */
   def xorErrorsAsAdts(res0: String) = {
     import XorStyleWithAdts._
 
@@ -287,125 +292,125 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** = Xor in the small, Xor in the large =
-    *
-    * Once you start using `Xor` for all your error-handling, you may quickly run into an issue where
-    * you need to call into two separate modules which give back separate kinds of errors.
-    *
-    * {{{
-    * sealed abstract class DatabaseError
-    * trait DatabaseValue
-    *
-    * object Database {
-    * def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
-    * }
-    *
-    * sealed abstract class ServiceError
-    * trait ServiceValue
-    *
-    * object Service {
-    * def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
-    * }
-    * }}}
-    *
-    * Let's say we have an application that wants to do database things, and then take database
-    * values and do service things. Glancing at the types, it looks like `flatMap` will do it.
-    *
-    * {{{
-    * def doApp = Database.databaseThings().flatMap(Service.serviceThings)
-    * }}}
-    *
-    * This doesn't work! Well, it does, but it gives us `Xor[Object, ServiceValue]` which isn't
-    * particularly useful for us. Now if we inspect the `Left`s, we have no clue what it could be.
-    * The reason this occurs is because the first type parameter in the two `Xor`s are different -
-    * `databaseThings()` can give us a `DatabaseError` whereas `serviceThings()` can give us a
-    * `ServiceError`: two completely unrelated types. Recall that the type parameters of `Xor`
-    * are covariant, so when it sees an `Xor[E1, A1]` and an `Xor[E2, A2]`, it will happily try
-    * to unify the `E1` and `E2` in a `flatMap` call - in our case, the closest common supertype is
-    * `Object`, leaving us with practically no type information to use in our pattern match.
-    *
-    * == Solution 1: Application-wide errors ==
-    *
-    * So clearly in order for us to easily compose `Xor` values, the left type parameter must be the same.
-    * We may then be tempted to make our entire application share an error data type.
-    *
-    * {{{
-    * sealed abstract class AppError
-    * final case object DatabaseError1 extends AppError
-    * final case object DatabaseError2 extends AppError
-    * final case object ServiceError1 extends AppError
-    * final case object ServiceError2 extends AppError
-    *
-    * trait DatabaseValue
-    *
-    * object Database {
-    * def databaseThings(): Xor[AppError, DatabaseValue] = ???
-    * }
-    *
-    * object Service {
-    * def serviceThings(v: DatabaseValue): Xor[AppError, ServiceValue] = ???
-    * }
-    *
-    * def doApp = Database.databaseThings().flatMap(Service.serviceThings)
-    * }}}
-    *
-    * This certainly works, or at least it compiles. But consider the case where another module wants to just use
-    * `Database`, and gets an `Xor[AppError, DatabaseValue]` back. Should it want to inspect the errors, it
-    * must inspect **all** the `AppError` cases, even though it was only intended for `Database` to use
-    * `DatabaseError1` or `DatabaseError2`.
-    *
-    * == Solution 2: ADTs all the way down ==
-    *
-    * Instead of lumping all our errors into one big ADT, we can instead keep them local to each module, and have
-    * an application-wide error ADT that wraps each error ADT we need.
-    *
-    * {{{
-    * sealed abstract class DatabaseError
-    * trait DatabaseValue
-    *
-    * object Database {
-    * def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
-    * }
-    *
-    * sealed abstract class ServiceError
-    * trait ServiceValue
-    *
-    * object Service {
-    * def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
-    * }
-    *
-    * sealed abstract class AppError
-    * object AppError {
-    * final case class Database(error: DatabaseError) extends AppError
-    * final case class Service(error: ServiceError) extends AppError
-    * }
-    * }}}
-    *
-    * Now in our outer application, we can wrap/lift each module-specific error into `AppError` and then
-    * call our combinators as usual. `Xor` provides a convenient method to assist with this, called `Xor.leftMap` -
-    * it can be thought of as the same as `map`, but for the `Left` side.
-    *
-    * {{{
-    * def doApp: Xor[AppError, ServiceValue] =
-    * Database.databaseThings().leftMap(AppError.Database).
-    * flatMap(dv => Service.serviceThings(dv).leftMap(AppError.Service))
-    * }}}
-    *
-    * Hurrah! Each module only cares about its own errors as it should be, and more composite modules have their
-    * own error ADT that encapsulates each constituent module's error ADT. Doing this also allows us to take action
-    * on entire classes of errors instead of having to pattern match on each individual one.
-    *
-    * {{{
-    * def awesome =
-    * doApp match {
-    *  case Xor.Left(AppError.Database(_)) => "something in the database went wrong"
-    *  case Xor.Left(AppError.Service(_))  => "something in the service went wrong"
-    *  case Xor.Right(_)                   => "everything is alright!"
-    * }
-    * }}}
-    *
-    * Let's review the `leftMap` and `map` methods:
-    *
-    */
+   *
+   * Once you start using `Xor` for all your error-handling, you may quickly run into an issue where
+   * you need to call into two separate modules which give back separate kinds of errors.
+   *
+   * {{{
+   * sealed abstract class DatabaseError
+   * trait DatabaseValue
+   *
+   * object Database {
+   * def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
+   * }
+   *
+   * sealed abstract class ServiceError
+   * trait ServiceValue
+   *
+   * object Service {
+   * def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
+   * }
+   * }}}
+   *
+   * Let's say we have an application that wants to do database things, and then take database
+   * values and do service things. Glancing at the types, it looks like `flatMap` will do it.
+   *
+   * {{{
+   * def doApp = Database.databaseThings().flatMap(Service.serviceThings)
+   * }}}
+   *
+   * This doesn't work! Well, it does, but it gives us `Xor[Object, ServiceValue]` which isn't
+   * particularly useful for us. Now if we inspect the `Left`s, we have no clue what it could be.
+   * The reason this occurs is because the first type parameter in the two `Xor`s are different -
+   * `databaseThings()` can give us a `DatabaseError` whereas `serviceThings()` can give us a
+   * `ServiceError`: two completely unrelated types. Recall that the type parameters of `Xor`
+   * are covariant, so when it sees an `Xor[E1, A1]` and an `Xor[E2, A2]`, it will happily try
+   * to unify the `E1` and `E2` in a `flatMap` call - in our case, the closest common supertype is
+   * `Object`, leaving us with practically no type information to use in our pattern match.
+   *
+   * == Solution 1: Application-wide errors ==
+   *
+   * So clearly in order for us to easily compose `Xor` values, the left type parameter must be the same.
+   * We may then be tempted to make our entire application share an error data type.
+   *
+   * {{{
+   * sealed abstract class AppError
+   * final case object DatabaseError1 extends AppError
+   * final case object DatabaseError2 extends AppError
+   * final case object ServiceError1 extends AppError
+   * final case object ServiceError2 extends AppError
+   *
+   * trait DatabaseValue
+   *
+   * object Database {
+   * def databaseThings(): Xor[AppError, DatabaseValue] = ???
+   * }
+   *
+   * object Service {
+   * def serviceThings(v: DatabaseValue): Xor[AppError, ServiceValue] = ???
+   * }
+   *
+   * def doApp = Database.databaseThings().flatMap(Service.serviceThings)
+   * }}}
+   *
+   * This certainly works, or at least it compiles. But consider the case where another module wants to just use
+   * `Database`, and gets an `Xor[AppError, DatabaseValue]` back. Should it want to inspect the errors, it
+   * must inspect **all** the `AppError` cases, even though it was only intended for `Database` to use
+   * `DatabaseError1` or `DatabaseError2`.
+   *
+   * == Solution 2: ADTs all the way down ==
+   *
+   * Instead of lumping all our errors into one big ADT, we can instead keep them local to each module, and have
+   * an application-wide error ADT that wraps each error ADT we need.
+   *
+   * {{{
+   * sealed abstract class DatabaseError
+   * trait DatabaseValue
+   *
+   * object Database {
+   * def databaseThings(): Xor[DatabaseError, DatabaseValue] = ???
+   * }
+   *
+   * sealed abstract class ServiceError
+   * trait ServiceValue
+   *
+   * object Service {
+   * def serviceThings(v: DatabaseValue): Xor[ServiceError, ServiceValue] = ???
+   * }
+   *
+   * sealed abstract class AppError
+   * object AppError {
+   * final case class Database(error: DatabaseError) extends AppError
+   * final case class Service(error: ServiceError) extends AppError
+   * }
+   * }}}
+   *
+   * Now in our outer application, we can wrap/lift each module-specific error into `AppError` and then
+   * call our combinators as usual. `Xor` provides a convenient method to assist with this, called `Xor.leftMap` -
+   * it can be thought of as the same as `map`, but for the `Left` side.
+   *
+   * {{{
+   * def doApp: Xor[AppError, ServiceValue] =
+   * Database.databaseThings().leftMap(AppError.Database).
+   * flatMap(dv => Service.serviceThings(dv).leftMap(AppError.Service))
+   * }}}
+   *
+   * Hurrah! Each module only cares about its own errors as it should be, and more composite modules have their
+   * own error ADT that encapsulates each constituent module's error ADT. Doing this also allows us to take action
+   * on entire classes of errors instead of having to pattern match on each individual one.
+   *
+   * {{{
+   * def awesome =
+   * doApp match {
+   *  case Xor.Left(AppError.Database(_)) => "something in the database went wrong"
+   *  case Xor.Left(AppError.Service(_))  => "something in the service went wrong"
+   *  case Xor.Right(_)                   => "everything is alright!"
+   * }
+   * }}}
+   *
+   * Let's review the `leftMap` and `map` methods:
+   *
+   */
   def xorInTheLarge(res0: String Xor Int, res1: String Xor Int, res2: String Xor Int) = {
     val right: String Xor Int = Xor.Right(41)
     right.map(_ + 1) should be(res0)
@@ -416,30 +421,30 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** There will inevitably come a time when your nice `Xor` code will have to interact with exception-throwing
-    * code. Handling such situations is easy enough.
-    *
-    * {{{
-    * val xor: Xor[NumberFormatException, Int] =
-    * try {
-    *  Xor.right("abc".toInt)
-    * } catch {
-    *  case nfe: NumberFormatException => Xor.left(nfe)
-    * }
-    * }}}
-    *
-    * However, this can get tedious quickly. `Xor` provides a `catchOnly` method on its companion object
-    * that allows you to pass it a function, along with the type of exception you want to catch, and does the
-    * above for you.
-    *
-    * {{{
-    * val xor: Xor[NumberFormatException, Int] =
-    * Xor.catchOnly[NumberFormatException]("abc".toInt)
-    * }}}
-    *
-    * If you want to catch all (non-fatal) throwables, you can use `catchNonFatal`.
-    *
-    *
-    */
+   * code. Handling such situations is easy enough.
+   *
+   * {{{
+   * val xor: Xor[NumberFormatException, Int] =
+   * try {
+   *  Xor.right("abc".toInt)
+   * } catch {
+   *  case nfe: NumberFormatException => Xor.left(nfe)
+   * }
+   * }}}
+   *
+   * However, this can get tedious quickly. `Xor` provides a `catchOnly` method on its companion object
+   * that allows you to pass it a function, along with the type of exception you want to catch, and does the
+   * above for you.
+   *
+   * {{{
+   * val xor: Xor[NumberFormatException, Int] =
+   * Xor.catchOnly[NumberFormatException]("abc".toInt)
+   * }}}
+   *
+   * If you want to catch all (non-fatal) throwables, you can use `catchNonFatal`.
+   *
+   *
+   */
   def xorWithExceptions(res0: Boolean, res1: Boolean) = {
     Xor.catchOnly[NumberFormatException]("abc".toInt).isRight should be(res0)
 
@@ -447,21 +452,21 @@ object XorSection extends FlatSpec with Matchers with org.scalaexercises.definit
   }
 
   /** = Additional syntax =
-    *
-    * For using Xor's syntax on arbitrary data types, you can import `cats.implicits._`. This will
-    * make possible to use the `left` and `right` methods:
-    *
-    * {{{
-    * import cats.implicits._
-    *
-    * val right: Xor[String, Int] = 7.right[String]
-    *
-    * val left: Xor[String, Int] = "hello 🐈s".left[Int]
-    * }}}
-    *
-    * These method promote values to the `Xor` data type:
-    *
-    */
+   *
+   * For using Xor's syntax on arbitrary data types, you can import `cats.implicits._`. This will
+   * make possible to use the `left` and `right` methods:
+   *
+   * {{{
+   * import cats.implicits._
+   *
+   * val right: Xor[String, Int] = 7.right[String]
+   *
+   * val left: Xor[String, Int] = "hello 🐈s".left[Int]
+   * }}}
+   *
+   * These method promote values to the `Xor` data type:
+   *
+   */
   def xorSyntax(res0: String Xor Int) = {
     import cats.implicits._
 

--- a/src/test/scala/catslib/ApplicativeSpec.scala
+++ b/src/test/scala/catslib/ApplicativeSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/ApplySpec.scala
+++ b/src/test/scala/catslib/ApplySpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._
@@ -70,7 +75,7 @@ class ApplySpec extends Spec with Checkers {
   }
 
   def `builder syntax` = {
-    val aNone: Option[Int] = None
+    val aNone: Option[Int]                   = None
     val anotherNone: Option[(Int, Int, Int)] = None
 
     check(

--- a/src/test/scala/catslib/FoldableSpec.scala
+++ b/src/test/scala/catslib/FoldableSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/FunctorSpec.scala
+++ b/src/test/scala/catslib/FunctorSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/IdentitySpec.scala
+++ b/src/test/scala/catslib/IdentitySpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/MonadSpec.scala
+++ b/src/test/scala/catslib/MonadSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/MonoidSpec.scala
+++ b/src/test/scala/catslib/MonoidSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._
@@ -17,7 +22,7 @@ class MonoidSpec extends Spec with Checkers {
   }
 
   def `advantages of using monoid operations` = {
-    val aMap: Map[String, Int] = Map("a" → 4, "b" → 2)
+    val aMap: Map[String, Int]       = Map("a" → 4, "b" → 2)
     val anotherMap: Map[String, Int] = Map()
 
     check(

--- a/src/test/scala/catslib/SemigroupSpec.scala
+++ b/src/test/scala/catslib/SemigroupSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/TraverseSpec.scala
+++ b/src/test/scala/catslib/TraverseSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/ValidatedSpec.scala
+++ b/src/test/scala/catslib/ValidatedSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/catslib/XorSpec.scala
+++ b/src/test/scala/catslib/XorSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-cats
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package catslib
 
 import cats.data.Xor
@@ -66,7 +71,8 @@ class XorSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         XorSection.xorInTheLarge _,
-        Xor.right[String, Int](42) :: Xor.left[String, Int]("Hello") :: Xor.left[String, Int]("olleH") :: HNil
+        Xor.right[String, Int](42) :: Xor.left[String, Int]("Hello") :: Xor.left[String, Int](
+          "olleH") :: HNil
       )
     )
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
This integration has no effect on the deployed application since we are releasing a snapshot new version.

There are multiples changes across the source code, most of them due to scalafmt autoformatting or file headers. The important changes here are:

* build.sbt
* project/plugins.sbt
* project/build.properties
* project/ProjectPlugin.scala
* README.md
* travis.yml
* version.sbt

I'll create an issue to upgrade the cats version, which can be done in a separate PR.

Please, @raulraja could you review? Thanks!