### PR TITLE
Break apart a set of five tests

### DIFF
--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -45,25 +45,27 @@ object SemigroupSection
    * guess how it works in the following examples:
    *
    */
-  def semigroupCombine(
-      res0: Int,
-      res1: List[Int],
-      res2: Option[Int],
-      res3: Option[Int],
-      res4: Int) = {
+  def semigroupCombine(res0: Int, res1: List[Int], res2: Option[Int], res3: Option[Int]) = {
     import cats.implicits._
 
     Semigroup[Int].combine(1, 2) should be(res0)
     Semigroup[List[Int]].combine(List(1, 2, 3), List(4, 5, 6)) should be(res1)
     Semigroup[Option[Int]].combine(Option(1), Option(2)) should be(res2)
     Semigroup[Option[Int]].combine(Option(1), None) should be(res3)
+  }
+
+  /** And now try a slightly more complex combination:
+   */
+  def semigroupCombineComplex(res0: Int) = {
+    import cats.implicits._
+
     Semigroup[Int ⇒ Int]
       .combine({ (x: Int) ⇒
         x + 1
       }, { (x: Int) ⇒
         x * 10
       })
-      .apply(6) should be(res4)
+      .apply(6) should be(res0)
   }
 
   /** Many of these types have methods defined directly on them,

--- a/src/test/scala/catslib/SemigroupSpec.scala
+++ b/src/test/scala/catslib/SemigroupSpec.scala
@@ -16,7 +16,16 @@ class SemigroupSpec extends RefSpec with Checkers {
     check(
       Test.testSuccess(
         SemigroupSection.semigroupCombine _,
-        3 :: List(1, 2, 3, 4, 5, 6) :: Option(3) :: Option(1) :: 67 :: HNil
+        3 :: List(1, 2, 3, 4, 5, 6) :: Option(3) :: Option(1) :: HNil
+      )
+    )
+  }
+
+  def `has an advanced combine operation` = {
+    check(
+      Test.testSuccess(
+        SemigroupSection.semigroupCombineComplex _,
+        67 :: HNil
       )
     )
   }


### PR DESCRIPTION
I was taking these tests for my first time and I found the first question confusing. When the answer I submitted failed, I could not tell whether it was because I didn't understand how .combine() worked at all, or because one of my answers was wrong. 

This PR takes the fifth .combine() test and moves it to a separate question.  I think this will be fine because the first 4 .combine() tests are so similar.