### PR TITLE
Omit explicit parameter types of anonymous functions

### DIFF
--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -58,7 +58,7 @@ object SemigroupSection
   def semigroupCombineComplex(res0: Int) = {
     import cats.implicits._
 
-    Semigroup[Int => Int].combine(_ + 1 ,  _ * 10).apply(6) should be(res0)
+    Semigroup[Int => Int].combine(_ + 1, _ * 10).apply(6) should be(res0)
 
   }
 

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -58,7 +58,7 @@ object SemigroupSection
   def semigroupCombineComplex(res0: Int) = {
     import cats.implicits._
 
-    Semigroup[Int => Int].combine({ _ + 1 }, { _ * 10 }).apply(6) should be(res0)
+    Semigroup[Int => Int].combine(_ + 1 ,  _ * 10).apply(6) should be(res0)
 
   }
 

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -5,6 +5,7 @@
 
 package catslib
 
+import cats.kernel.Semigroup
 import org.scalatest._
 
 /** A semigroup for some given type A has a single operation

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -7,8 +7,6 @@ package catslib
 
 import org.scalatest._
 
-import cats._
-
 /** A semigroup for some given type A has a single operation
  * (which we will call `combine`), which takes two values of type A, and
  * returns a value of type A. This operation must be guaranteed to be
@@ -59,13 +57,8 @@ object SemigroupSection
   def semigroupCombineComplex(res0: Int) = {
     import cats.implicits._
 
-    Semigroup[Int ⇒ Int]
-      .combine({ (x: Int) ⇒
-        x + 1
-      }, { (x: Int) ⇒
-        x * 10
-      })
-      .apply(6) should be(res0)
+    Semigroup[Int => Int].combine({ _ + 1 }, { _ * 10 }).apply(6) should be(res0)
+
   }
 
   /** Many of these types have methods defined directly on them,


### PR DESCRIPTION
We can omit the naming of types, as we mentioned this earlier. Does not interfere with the task.