### PR TITLE
Fix minor bug in code snippet example

### DIFF
--- a/src/main/scala/catslib/Validated.scala
+++ b/src/main/scala/catslib/Validated.scala
@@ -57,7 +57,7 @@ import ValidatedHelpers._
  * def apply[A](implicit A: Read[A]): Read[A] = A
  *
  * implicit val stringRead: Read[String] =
- *  new Read[String] { def read(s: String): Option[String] = Some(s) }
+ *  new Read[String] { def read(s: String): Option[String] = Option(s) }
  *
  * implicit val intRead: Read[Int] =
  *  new Read[Int] {


### PR DESCRIPTION
In the code snippet there was used `Some` for creating optional value from `String`, although string passed to `Some` would produce `Some(null)`, instead of `None`