### PR TITLE
Exercises Update to Scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
 - 2.12.10
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - sbt test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.11.11
+- 2.12.10
 jdk:
 - oraclejdk8
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercis
 
 lazy val cats = (project in file("."))
   .enablePlugins(ExerciseCompilerPlugin)
-  //.disablePlugins(CoursierPlugin)
   .settings(
     name         := "exercises-cats",
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,23 @@
-val scalaExercisesV = "0.4.0-SNAPSHOT"
+import ProjectPlugin.autoImport._
+val scalaExercisesV = "0.5.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 
 lazy val cats = (project in file("."))
   .enablePlugins(ExerciseCompilerPlugin)
-  .disablePlugins(CoursierPlugin)
+  //.disablePlugins(CoursierPlugin)
   .settings(
     name         := "exercises-cats",
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("cats"),
-      %%("shapeless"),
-      %%("scalatest"),
-      %%("scalacheck"),
-      %%("scheckShapeless")
-    )
+      %%("cats-core", V.cats),
+      %%("shapeless", V.shapeless),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+    ),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
   )
 
 // Distribution

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,4 +1,4 @@
-import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.License._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys._
 import sbt._
@@ -11,6 +11,20 @@ object ProjectPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val V = new {
+      val scala212: String            = "2.12.10"
+      val cats: String = "2.0.0"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
+    }
+  }
+
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -25,22 +39,17 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := "2.11.11",
+      scalaVersion := V.scala212,
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := Seq("2.11.11"),
       resolvers ++= Seq(
         Resolver.mavenLocal,
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases")
       ),
-      headers := Map(
-        "scala" -> (HeaderPattern.cStyleBlockComment,
-          s"""|/*
-              | * scala-exercises - ${name.value}
-              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
-              | */
-              |
-            |""".stripMargin)
-      )
+      scalacOptions += "-Ypartial-unification",
+      headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+                                       |
+                                       |""".stripMargin))
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.13")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/catslib/Applicative.scala
+++ b/src/main/scala/catslib/Applicative.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/Apply.scala
+++ b/src/main/scala/catslib/Apply.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
@@ -147,11 +148,11 @@ object ApplySection extends FlatSpec with Matchers with org.scalaexercises.defin
       res5: Option[(Int, Int, Int)]
   ) = {
     import cats.implicits._
-    val option2 = Option(1) |@| Option(2)
-    val option3 = option2 |@| Option.empty[Int]
+    val option2 = (Option(1), Option(2))
+    val option3 = (option2._1, option2._2, Option.empty[Int])
 
-    option2 map addArity2 should be(res0)
-    option3 map addArity3 should be(res1)
+    option2 mapN addArity2 should be(res0)
+    option3 mapN addArity3 should be(res1)
 
     option2 apWith Some(addArity2) should be(res2)
     option3 apWith Some(addArity3) should be(res3)

--- a/src/main/scala/catslib/ApplyHelpers.scala
+++ b/src/main/scala/catslib/ApplyHelpers.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/CatsLibrary.scala
+++ b/src/main/scala/catslib/CatsLibrary.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/EitherSection.scala
+++ b/src/main/scala/catslib/EitherSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/Foldable.scala
+++ b/src/main/scala/catslib/Foldable.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/FunctorSection.scala
+++ b/src/main/scala/catslib/FunctorSection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/IdentitySection.scala
+++ b/src/main/scala/catslib/IdentitySection.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/Monad.scala
+++ b/src/main/scala/catslib/Monad.scala
@@ -1,13 +1,13 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
 import org.scalatest._
 
-import cats._
 import MonadHelpers._
 
 /** `Monad` extends the `Applicative` type class with a
@@ -114,7 +114,7 @@ object MonadSection extends FlatSpec with Matchers with org.scalaexercises.defin
    * case class OptionT[F[_], A](value: F[Option[A]])
 
    * implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
-   *   new Monad[OptionT[F, ?]] {
+   *   new Monad[OptionT[F, *]] {
    *     def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
    *     def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
    *       OptionT {

--- a/src/main/scala/catslib/MonadHelpers.scala
+++ b/src/main/scala/catslib/MonadHelpers.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
@@ -12,7 +13,7 @@ object MonadHelpers {
   case class OptionT[F[_], A](value: F[Option[A]])
 
   implicit def optionTMonad[F[_]](implicit F: Monad[F]) = {
-    new Monad[OptionT[F, ?]] {
+    new Monad[OptionT[F, *]] {
       def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
       def flatMap[A, B](fa: OptionT[F, A])(f: A ⇒ OptionT[F, B]): OptionT[F, B] =
         OptionT {

--- a/src/main/scala/catslib/Monoid.scala
+++ b/src/main/scala/catslib/Monoid.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
@@ -35,10 +36,7 @@ import org.scalatest._
  *
  * @param name semigroup
  */
-object SemigroupSection
-    extends FlatSpec
-    with Matchers
-    with org.scalaexercises.definitions.Section {
+object SemigroupSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** Now that you've learned about the `Semigroup` instance for `Int` try to
    * guess how it works in the following examples:

--- a/src/main/scala/catslib/Traverse.scala
+++ b/src/main/scala/catslib/Traverse.scala
@@ -1,13 +1,13 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
 import org.scalatest._
 
-import cats.data.ValidatedNel
 import cats.implicits._
 
 import TraverseHelpers._
@@ -92,13 +92,6 @@ object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.de
    * walks the `F[A]` depends on the effect of the function. Let's see some examples where `F` is taken to be
    * `List`.
    *
-   * Note in the following code snippet we are using `traverseU` instead of `traverse`.
-   * `traverseU` is for all intents and purposes the same as `traverse`, but with some
-   * [[http://typelevel.org/blog/2013/09/11/using-scalaz-Unapply.html type-level trickery]]
-   * to allow it to infer the `Applicative[Either[A, ?]]` and `Applicative[Validated[A, ?]]`
-   * instances - `scalac` has issues inferring the instances for data types that do not
-   * trivially satisfy the `F[_]` shape required by `Applicative`.
-   *
    * {{{
    * import cats.Semigroup
    * import cats.data.{NonEmptyList, OneAnd, Validated, ValidatedNel}
@@ -115,8 +108,8 @@ object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.de
    * and accumulating failures with `Either`.
    */
   def traverseuFunction(res0: List[Int], res1: Boolean) = {
-    List("1", "2", "3").traverseU(parseIntEither) should be(Right(res0))
-    List("1", "abc", "3").traverseU(parseIntEither).isLeft should be(res1)
+    List("1", "2", "3").traverse(parseIntEither) should be(Right(res0))
+    List("1", "abc", "3").traverse(parseIntEither).isLeft should be(res1)
   }
 
   /** We need proof that `NonEmptyList[A]` is a `Semigroup `for there to be an `Applicative` instance for
@@ -129,12 +122,8 @@ object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.de
    *
    * Now that we've provided such evidence, we can use `ValidatedNel` as an applicative.
    */
-  def traverseuValidated(res0: Boolean) = {
-    import cats.Semigroup
-    import cats.data.{NonEmptyList, OneAnd, ValidatedNel}
-
-    List("1", "2", "3").traverseU(parseIntValidated).isValid should be(res0)
-  }
+  def traverseuValidated(res0: Boolean) =
+    List("1", "2", "3").traverse(parseIntValidated).isValid should be(res0)
 
   /** Notice that in the `Either` case, should any string fail to parse the entire traversal
    * is considered a failure. Moreover, once it hits its first bad parse, it will not

--- a/src/main/scala/catslib/TraverseHelpers.scala
+++ b/src/main/scala/catslib/TraverseHelpers.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib

--- a/src/main/scala/catslib/Validated.scala
+++ b/src/main/scala/catslib/Validated.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
@@ -165,10 +166,7 @@ import ValidatedHelpers._
  *
  * @param name validated
  */
-object ValidatedSection
-    extends FlatSpec
-    with Matchers
-    with org.scalaexercises.definitions.Section {
+object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** When no errors are present in the configuration, we get a `ConnectionParams` wrapped in a `Valid` instance.
    */
@@ -358,8 +356,6 @@ object ValidatedSection
    *
    */
   def validatedAsEither(res0: Boolean, res1: Boolean) = {
-    import cats.implicits._
-
     val config = Config(Map("house_number" → "-42"))
 
     val houseNumber = config.parse[Int]("house_number").withEither {

--- a/src/main/scala/catslib/ValidatedHelpers.scala
+++ b/src/main/scala/catslib/ValidatedHelpers.scala
@@ -1,15 +1,10 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
-
-import cats.{Semigroup, SemigroupK}
-import cats.data.NonEmptyList
-import cats.data.Validated
-import cats.data.Validated.{Invalid, Valid}
-import cats.implicits._
 
 object ValidatedHelpers {
   case class ConnectionParams(url: String, port: Int)
@@ -72,8 +67,7 @@ object ValidatedHelpers {
   implicit val readString: Read[String] = Read.stringRead
   implicit val readInt: Read[Int]       = Read.intRead
 
-  def positive(field: String, i: Int): Either[ConfigError, Int] = {
+  def positive(field: String, i: Int): Either[ConfigError, Int] =
     if (i >= 0) Either.right(i)
     else Either.left(ParseError(field))
-  }
 }

--- a/src/test/scala/catslib/ApplicativeSpec.scala
+++ b/src/test/scala/catslib/ApplicativeSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/ApplySpec.scala
+++ b/src/test/scala/catslib/ApplySpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/EitherSpec.scala
+++ b/src/test/scala/catslib/EitherSpec.scala
@@ -1,14 +1,15 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
 import cats.implicits._
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/FoldableSpec.scala
+++ b/src/test/scala/catslib/FoldableSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/FunctorSpec.scala
+++ b/src/test/scala/catslib/FunctorSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/IdentitySpec.scala
+++ b/src/test/scala/catslib/IdentitySpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/MonadSpec.scala
+++ b/src/test/scala/catslib/MonadSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/MonoidSpec.scala
+++ b/src/test/scala/catslib/MonoidSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/SemigroupSpec.scala
+++ b/src/test/scala/catslib/SemigroupSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/TraverseSpec.scala
+++ b/src/test/scala/catslib/TraverseSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/src/test/scala/catslib/ValidatedSpec.scala
+++ b/src/test/scala/catslib/ValidatedSpec.scala
@@ -1,13 +1,14 @@
 /*
- * scala-exercises - exercises-cats
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-cats
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package catslib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.refspec.RefSpec
 import shapeless.HNil
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates `exercises-cats` to Scala 2.12.10 and it's dependencies. Also, removes deprecated warnings because of the upgrade.