### PR TITLE
ScalaCheck Update 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val cats = (project in file("."))
       %%("shapeless", V.shapeless),
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless,
+      "org.scalatestplus" %% "scalatestplus-scalacheck" % V.scalatestplusScheck
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
   )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,10 +1,10 @@
-import de.heikoseeberger.sbtheader.License._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.License._
 import sbt.Keys._
 import sbt._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies._
 import sbtorgpolicies.model._
-import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -16,9 +16,10 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val scala212: String            = "2.12.10"
-      val cats: String = "2.0.0"
+      val cats: String                = "2.0.0"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
     }

--- a/src/main/scala/catslib/Applicative.scala
+++ b/src/main/scala/catslib/Applicative.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats._
 import cats.implicits._
@@ -21,7 +22,7 @@ import cats.implicits._
  * @param name applicative
  */
 object ApplicativeSection
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/catslib/Apply.scala
+++ b/src/main/scala/catslib/Apply.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import ApplyHelpers._
 
 import cats._
@@ -46,7 +47,7 @@ import cats.implicits._
  *
  * @param name apply
  */
-object ApplySection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object ApplySection extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** = map =
    *

--- a/src/main/scala/catslib/EitherSection.scala
+++ b/src/main/scala/catslib/EitherSection.scala
@@ -8,7 +8,8 @@ package catslib
 
 import cats.implicits._
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 object EitherStyle {
   def parse(s: String): Either[NumberFormatException, Int] =
@@ -79,7 +80,7 @@ object EitherStyleWithAdts {
  *
  * @param name either
  */
-object EitherSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object EitherSection extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** More often than not we want to just bias towards one side and call it a day - by convention,
    * the right side is most often chosen.

--- a/src/main/scala/catslib/Foldable.scala
+++ b/src/main/scala/catslib/Foldable.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats._
 import cats.implicits._
@@ -39,7 +40,10 @@ import cats.implicits._
  *
  * @param name foldable
  */
-object FoldableSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object FoldableSection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** = foldLeft =
    *

--- a/src/main/scala/catslib/FunctorSection.scala
+++ b/src/main/scala/catslib/FunctorSection.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats._
 import cats.implicits._
@@ -72,7 +73,10 @@ import cats.implicits._
  *
  * @param name functor
  */
-object FunctorSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object FunctorSection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** = Using Functor =
    *

--- a/src/main/scala/catslib/IdentitySection.scala
+++ b/src/main/scala/catslib/IdentitySection.scala
@@ -7,7 +7,8 @@
 package catslib
 
 import cats._
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /** The identity monad can be seen as the ambient monad that encodes the
  * effect of having no effect. It is ambient in the sense that plain pure
@@ -32,7 +33,10 @@ import org.scalatest._
  *
  * @param name identity
  */
-object IdentitySection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object IdentitySection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** We can freely compare values of `Id[T]` with unadorned
    * values of type `T`.

--- a/src/main/scala/catslib/Monad.scala
+++ b/src/main/scala/catslib/Monad.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import MonadHelpers._
 
@@ -17,7 +18,7 @@ import MonadHelpers._
  *
  * @param name monad
  */
-object MonadSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object MonadSection extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** The name `flatten` should remind you of the functions of the same name on many
    * classes in the standard library.

--- a/src/main/scala/catslib/Monoid.scala
+++ b/src/main/scala/catslib/Monoid.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats._
 import cats.implicits._
@@ -30,7 +31,7 @@ import cats.implicits._
  *
  * @param name monoid
  */
-object MonoidSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object MonoidSection extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** First some imports.
    *

--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -7,7 +7,8 @@
 package catslib
 
 import cats.kernel.Semigroup
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /** A semigroup for some given type A has a single operation
  * (which we will call `combine`), which takes two values of type A, and
@@ -36,7 +37,10 @@ import org.scalatest._
  *
  * @param name semigroup
  */
-object SemigroupSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object SemigroupSection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** Now that you've learned about the `Semigroup` instance for `Int` try to
    * guess how it works in the following examples:

--- a/src/main/scala/catslib/Traverse.scala
+++ b/src/main/scala/catslib/Traverse.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats.implicits._
 
@@ -84,7 +85,10 @@ import TraverseHelpers._
  *
  * @param name traverse
  */
-object TraverseSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object TraverseSection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** == Choose your effect ==
    *

--- a/src/main/scala/catslib/Validated.scala
+++ b/src/main/scala/catslib/Validated.scala
@@ -6,7 +6,8 @@
 
 package catslib
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import cats.data.Validated
 
@@ -166,7 +167,10 @@ import ValidatedHelpers._
  *
  * @param name validated
  */
-object ValidatedSection extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object ValidatedSection
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** When no errors are present in the configuration, we get a `ConnectionParams` wrapped in a `Valid` instance.
    */


### PR DESCRIPTION
This PR updates ScalaCheck dependency to version 3.1.0.