### PR TITLE
null narrative references to |@| removed

### DIFF
--- a/src/main/scala/catslib/Apply.scala
+++ b/src/main/scala/catslib/Apply.scala
@@ -133,12 +133,8 @@ object ApplySection extends AnyFlatSpec with Matchers with org.scalaexercises.de
 
   /** = apply builder syntax =
    *
-   * The `|@|` operator offers an alternative syntax for the higher-arity `Apply`
-   * functions (`apN`, `mapN` and `tupleN`).
-   * In order to use it, first import `cats.implicits._`.
-   *
-   * All instances created by `|@|` have `map`, `ap`, and `tupled` methods of the appropriate arity:
-   *
+   * In order to use functions `apN`, `mapN` and `tupleN` *infix*,
+   * import `cats.implicits._`.
    */
   def applyBuilderSyntax(
       res0: Option[Int],


### PR DESCRIPTION
the `|@|` Cartesian operator is deprecated. The absence of the exercises themselves reflect this. However, the exercise verbiage is still present. This has 2 problems:
1. Dissonance between introduction verbiage to the exercise and the exercises themselves.
2. Teaching material that has reduced pedagogical value since it encourages to use features that should be and are otherwise discouraged since they will no longer be offered.