### PR TITLE
Add a link to the documentation referenced

### DIFF
--- a/src/main/scala/catslib/EitherSection.scala
+++ b/src/main/scala/catslib/EitherSection.scala
@@ -86,7 +86,8 @@ object EitherStyleWithAdts {
  * =`Either` vs `Validated`=
  *
  * In general, `Validated` is used to accumulate errors, while `Either` is used to short-circuit a computation upon the
- * first error. For more information, see the [`Validated` vs `Either`](https://typelevel.org/cats/datatypes/validated.html#validated-vs-either) 
+ * first error. For more information, see the
+ * [`Validated` vs `Either`](https://typelevel.org/cats/datatypes/validated.html#validated-vs-either)
  * section of the `Validated` documentation.
  *
  * @param name either

--- a/src/main/scala/catslib/EitherSection.scala
+++ b/src/main/scala/catslib/EitherSection.scala
@@ -86,7 +86,8 @@ object EitherStyleWithAdts {
  * =`Either` vs `Validated`=
  *
  * In general, `Validated` is used to accumulate errors, while `Either` is used to short-circuit a computation upon the
- * first error. For more information, see the `Validated` vs `Either` section of the `Validated` documentation.
+ * first error. For more information, see the [`Validated` vs `Either`](https://typelevel.org/cats/datatypes/validated.html#validated-vs-either) 
+ * section of the `Validated` documentation.
  *
  * @param name either
  */


### PR DESCRIPTION
I'm not sure if Scala Exercises is intended to be a project that encourages linking out to other resources like a blog post, but in the case that such an action is acceptable, I think it would be cool to have the documentation linked in this specific reference.