### PR TITLE
Replace deprecated kind-projector syntax [use '*' instead of '?']

### DIFF
--- a/src/main/scala/catslib/EitherSection.scala
+++ b/src/main/scala/catslib/EitherSection.scala
@@ -115,8 +115,8 @@ object EitherSection extends AnyFlatSpec with Matchers with org.scalaexercises.d
    * import cats.implicits._
    * import cats.Monad
    *
-   * implicit def eitherMonad[Err]: Monad[Either[Err, ?]] =
-   * new Monad[Either[Err, ?]] {
+   * implicit def eitherMonad[Err]: Monad[Either[Err, *]] =
+   * new Monad[Either[Err, *]] {
    *  def flatMap[A, B](fa: Either[Err, A])(f: A => Either[Err, B]): Either[Err, B] =
    *    fa.flatMap(f)
    *

--- a/src/main/scala/catslib/FunctorSection.scala
+++ b/src/main/scala/catslib/FunctorSection.scala
@@ -23,9 +23,9 @@ import cats._
 import cats.implicits._
 
 /** A `Functor` is a ubiquitous type class involving types that have one
- * "hole", i.e. types which have the shape `F[?]`, such as `Option`,
+ * "hole", i.e. types which have the shape `F[*]`, such as `Option`,
  * `List` and `Future`. (This is in contrast to a type like `Int` which has
- * no hole, or `Tuple2` which has two holes (`Tuple2[?,?]`)).
+ * no hole, or `Tuple2` which has two holes (`Tuple2[*,*]`)).
  *
  * The `Functor` category involves a single operation, named `map`:
  *
@@ -62,12 +62,12 @@ import cats.implicits._
  * }}}
  *
  * However, functors can also be created for types which don't have a `map`
- * method. For example, if we create a `Functor` for `Function1[In, ?]`
+ * method. For example, if we create a `Functor` for `Function1[In, *]`
  * we can use `andThen` to implement `map`:
  *
  * {{{
- * implicit def function1Functor[In]: Functor[Function1[In, ?]] =
- * new Functor[Function1[In, ?]] {
+ * implicit def function1Functor[In]: Functor[Function1[In, *]] =
+ * new Functor[Function1[In, *]] {
  *  def map[A,B](fa: In => A)(f: A => B): Function1[In,B] = fa andThen f
  * }
  * }}}
@@ -76,8 +76,8 @@ import cats.implicits._
  * [[https://github.com/non/kind-projector kind-projector compiler plugin]]
  * This compiler plugin can help us when we need to change the number of type
  * holes. In the example above, we took a type which normally has two type holes,
- * `Function1[?,?]` and constrained one of the holes to be the `In` type,
- * leaving just one hole for the return type, resulting in `Function1[In,?]`.
+ * `Function1[*,*]` and constrained one of the holes to be the `In` type,
+ * leaving just one hole for the return type, resulting in `Function1[In,*]`.
  * Without kind-projector, we'd have to write this as something like
  * `({type F[A] = Function1[In,A]})#F`, which is much harder to read and understand.
  *

--- a/src/main/scala/catslib/Validated.scala
+++ b/src/main/scala/catslib/Validated.scala
@@ -230,8 +230,8 @@ object ValidatedSection
    * {{{
    * import cats.Applicative
    *
-   * implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, ?]] =
-   * new Applicative[Validated[E, ?]] {
+   * implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, *]] =
+   * new Applicative[Validated[E, *]] {
    *  def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
    *    (fa, f) match {
    *      case (Valid(a), Valid(fab)) => Valid(fab(a))
@@ -269,7 +269,7 @@ object ValidatedSection
    *
    * {{{
    * val personFromConfig: ValidatedNel[ConfigError, Person] =
-   * Apply[ValidatedNel[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNel,
+   * Apply[ValidatedNel[ConfigError, *]].map4(config.parse[String]("name").toValidatedNel,
    *                                         config.parse[Int]("age").toValidatedNel,
    *                                         config.parse[Int]("house_number").toValidatedNel,
    *                                         config.parse[String]("street").toValidatedNel) {
@@ -287,8 +287,8 @@ object ValidatedSection
    * {{{
    * import cats.Monad
    *
-   * implicit def validatedMonad[E]: Monad[Validated[E, ?]] =
-   * new Monad[Validated[E, ?]] {
+   * implicit def validatedMonad[E]: Monad[Validated[E, *]] =
+   * new Monad[Validated[E, *]] {
    *  def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
    *    fa match {
    *      case Valid(a)     => f(a)


### PR DESCRIPTION
Replace deprecated kind-projector syntax [use '*' instead of '?'].